### PR TITLE
Add missing indexes on _parent_oid fields

### DIFF
--- a/src/trunk/libs/seiscomp3/datamodel/share/mysql.sql
+++ b/src/trunk/libs/seiscomp3/datamodel/share/mysql.sql
@@ -228,6 +228,7 @@ CREATE TABLE AmplitudeReference (
 	_last_modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	amplitudeID VARCHAR(255) NOT NULL,
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	INDEX(amplitudeID),
 	FOREIGN KEY(_oid)
 	  REFERENCES Object(_oid)
@@ -612,6 +613,7 @@ CREATE TABLE Magnitude (
 	creationInfo_version VARCHAR(64),
 	creationInfo_used TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	FOREIGN KEY(_oid)
 	  REFERENCES Object(_oid)
 	  ON DELETE CASCADE,
@@ -650,6 +652,7 @@ CREATE TABLE StationMagnitude (
 	creationInfo_version VARCHAR(64),
 	creationInfo_used TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	INDEX(amplitudeID),
 	FOREIGN KEY(_oid)
 	  REFERENCES Object(_oid)
@@ -706,6 +709,7 @@ CREATE TABLE Pick (
 	creationInfo_version VARCHAR(64),
 	creationInfo_used TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	INDEX(time_value),
 	INDEX(time_value_ms),
 	FOREIGN KEY(_oid)
@@ -722,6 +726,7 @@ CREATE TABLE OriginReference (
 	_last_modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	originID VARCHAR(255) NOT NULL,
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	INDEX(originID),
 	FOREIGN KEY(_oid)
 	  REFERENCES Object(_oid)
@@ -768,6 +773,7 @@ CREATE TABLE Event (
 	creationInfo_version VARCHAR(64),
 	creationInfo_used TINYINT(1) NOT NULL DEFAULT '0',
 	PRIMARY KEY(_oid),
+	INDEX(_parent_oid),
 	INDEX(preferredOriginID),
 	INDEX(preferredMagnitudeID),
 	INDEX(preferredFocalMechanismID),

--- a/src/trunk/libs/seiscomp3/datamodel/share/postgres.sql
+++ b/src/trunk/libs/seiscomp3/datamodel/share/postgres.sql
@@ -621,6 +621,7 @@ CREATE TABLE Amplitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Amplitude__parent_oid ON Amplitude(_parent_oid);
 CREATE INDEX Amplitude_m_pickID ON Amplitude(m_pickID);
 
 CREATE TRIGGER Amplitude_update BEFORE UPDATE ON Amplitude FOR EACH ROW EXECUTE PROCEDURE update_modified();
@@ -682,6 +683,7 @@ CREATE TABLE Magnitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Magnitude__parent_oid ON Magnitude(_parent_oid);
 
 CREATE TRIGGER Magnitude_update BEFORE UPDATE ON Magnitude FOR EACH ROW EXECUTE PROCEDURE update_modified();
 
@@ -724,6 +726,7 @@ CREATE TABLE StationMagnitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX StationMagnitude__parent_oid ON StationMagnitude(_parent_oid);
 CREATE INDEX StationMagnitude_m_amplitudeID ON StationMagnitude(m_amplitudeID);
 
 CREATE TRIGGER StationMagnitude_update BEFORE UPDATE ON StationMagnitude FOR EACH ROW EXECUTE PROCEDURE update_modified();
@@ -784,6 +787,7 @@ CREATE TABLE Pick (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Pick__parent_oid ON Pick(_parent_oid);
 CREATE INDEX Pick_m_time_value ON Pick(m_time_value);
 CREATE INDEX Pick_m_time_value_ms ON Pick(m_time_value_ms);
 
@@ -858,6 +862,7 @@ CREATE TABLE Event (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Event__parent_oid ON Event(_parent_oid);
 CREATE INDEX Event_m_preferredOriginID ON Event(m_preferredOriginID);
 CREATE INDEX Event_m_preferredMagnitudeID ON Event(m_preferredMagnitudeID);
 CREATE INDEX Event_m_preferredFocalMechanismID ON Event(m_preferredFocalMechanismID);
@@ -989,6 +994,7 @@ CREATE TABLE Origin (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Origin__parent_oid ON Origin(_parent_oid);
 CREATE INDEX Origin_m_time_value ON Origin(m_time_value);
 CREATE INDEX Origin_m_time_value_ms ON Origin(m_time_value_ms);
 

--- a/src/trunk/libs/seiscomp3/datamodel/share/sqlite3.sql
+++ b/src/trunk/libs/seiscomp3/datamodel/share/sqlite3.sql
@@ -639,6 +639,7 @@ CREATE TABLE Amplitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Amplitude__parent_oid ON Amplitude(_parent_oid);
 CREATE INDEX Amplitude_pickID ON Amplitude(pickID);
 
 CREATE TRIGGER AmplitudeUpdate UPDATE ON Amplitude
@@ -704,6 +705,7 @@ CREATE TABLE Magnitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Magnitude__parent_oid ON Magnitude(_parent_oid);
 
 CREATE TRIGGER MagnitudeUpdate UPDATE ON Magnitude
 BEGIN
@@ -748,6 +750,7 @@ CREATE TABLE StationMagnitude (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX StationMagnitude__parent_oid ON StationMagnitude(_parent_oid);
 CREATE INDEX StationMagnitude_amplitudeID ON StationMagnitude(amplitudeID);
 
 CREATE TRIGGER StationMagnitudeUpdate UPDATE ON StationMagnitude
@@ -810,6 +813,7 @@ CREATE TABLE Pick (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Pick__parent_oid ON Pick(_parent_oid);
 CREATE INDEX Pick_time_value ON Pick(time_value);
 CREATE INDEX Pick_time_value_ms ON Pick(time_value_ms);
 
@@ -890,6 +894,7 @@ CREATE TABLE Event (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Event__parent_oid ON Event(_parent_oid);
 CREATE INDEX Event_preferredOriginID ON Event(preferredOriginID);
 CREATE INDEX Event_preferredMagnitudeID ON Event(preferredMagnitudeID);
 CREATE INDEX Event_preferredFocalMechanismID ON Event(preferredFocalMechanismID);
@@ -1025,6 +1030,7 @@ CREATE TABLE Origin (
 	  ON DELETE CASCADE
 );
 
+CREATE INDEX Origin__parent_oid ON Origin(_parent_oid);
 CREATE INDEX Origin_time_value ON Origin(time_value);
 CREATE INDEX Origin_time_value_ms ON Origin(time_value_ms);
 


### PR DESCRIPTION
As our database (~60M objects) is growing, we start to have a bottleneck while deleting objects. An example :

``` sql
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Delete on object  (cost=0.56..8.58 rows=1 width=6) (actual time=0.092..0.092 rows=0 loops=1)
   ->  Index Scan using object_pkey on object  (cost=0.56..8.58 rows=1 width=6) (actual time=0.022..0.022 rows=1 loops=1)
         Index Cond: (_oid = 59111468)
...
 Trigger for constraint event__parent_oid_fkey: time=30.287 calls=1
...
 Trigger for constraint magnitude__parent_oid_fkey: time=62.454 calls=1
...
 Trigger for constraint origin__parent_oid_fkey: time=46.817 calls=1
...
 Trigger for constraint pick__parent_oid_fkey: time=1452.192 calls=1
...
 Trigger for constraint stationmagnitude__parent_oid_fkey: time=308.730 calls=1
...
 Trigger for constraint amplitude__parent_oid_fkey: time=5662.127 calls=1
 Total runtime: 7639.337 ms
(117 rows)
```

It takes almost **8 seconds** to delete an object but we can see a lot of time is lost due to _parent_oid fields. After adding missing indexes, it takes only **6 ms** :

``` sql
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Delete on object  (cost=0.56..8.58 rows=1 width=6) (actual time=0.029..0.029 rows=0 loops=1)
   ->  Index Scan using object_pkey on object  (cost=0.56..8.58 rows=1 width=6) (actual time=0.013..0.013 rows=1 loops=1)
         Index Cond: (_oid = 59111466)
...
 Trigger for constraint event__parent_oid_fkey: time=0.036 calls=1
...
 Trigger for constraint magnitude__parent_oid_fkey: time=0.037 calls=1
...
 Trigger for constraint origin__parent_oid_fkey: time=0.042 calls=1
...
 Trigger for constraint pick__parent_oid_fkey: time=0.036 calls=1
...
 Trigger for constraint stationmagnitude__parent_oid_fkey: time=0.040 calls=1
...
 Trigger for constraint amplitude__parent_oid_fkey: time=0.105 calls=1
...
 Total runtime: 5.569 ms
(117 rows)
```
