### PR TITLE
Bug in tabinvmodifier

### DIFF
--- a/src/nettab/apps/tabinvmodifier/tabinvmodifier.py
+++ b/src/nettab/apps/tabinvmodifier/tabinvmodifier.py
@@ -270,10 +270,10 @@ class InventoryModifier(Client.Application):
         iv = Client.Inventory.Instance().inventory()
 
         if not rules:
-            return 1
+            return False
 
         if not iv:
-            return 1 
+            return False
 
         Logging.debug("Loaded %d networks" % iv.networkCount())
         if self.outputFile is None:

--- a/src/nettab/apps/tabinvmodifier/tabinvmodifier.py
+++ b/src/nettab/apps/tabinvmodifier/tabinvmodifier.py
@@ -311,7 +311,7 @@ class InventoryModifier(Client.Application):
             att = rules.getInstrumentsAttributes(datalogger.name(), "Dl")
             self._modifyInventory("datalogger", datalogger, att)
 
-        return 0
+        return True
 
     def done(self):
         if self.outputFile:


### PR DESCRIPTION
tabinvmodifier run() method was returning 0 instead of True rendering it unusable in newer environments (tested with swig 3.0.2-1 - debian/testing). This should correct this bug.