### PR TITLE
[scolv] Initial spectrogram implementation

### DIFF
--- a/src/gui-qt4/libs/seiscomp3/gui/core/CMakeLists.txt
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/CMakeLists.txt
@@ -26,6 +26,8 @@ SET(
 		inspector.cpp
 		tensorrenderer.cpp
 		uncertainties.cpp
+		spectrogramrenderer.cpp
+		spectrogramwidget.cpp
 )
 
 IF(MACOSX)
@@ -48,6 +50,7 @@ SET(
 		questionbox.h
 		utils.h
 		tensorrenderer.h
+		spectrogramrenderer.h
 )
 
 SET(
@@ -69,6 +72,7 @@ SET(
 		xmlview.h
 		inspector.h
 		uncertainties.h
+		spectrogramwidget.h
 )
 
 SET(

--- a/src/gui-qt4/libs/seiscomp3/gui/core/lut.h
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/lut.h
@@ -1,0 +1,127 @@
+/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#ifndef __SEISCOMP_GUI_LUT_H__
+#define __SEISCOMP_GUI_LUT_H__
+
+
+#include <seiscomp3/gui/core/gradient.h>
+#include <QRgb>
+
+
+namespace Seiscomp {
+namespace Gui {
+
+
+template<typename Key, typename Value>
+class LUT {
+	public:
+		typedef Key   key_type;
+		typedef Value value_type;
+
+
+	protected:
+		LUT(int n, Value *values) : _size(n), _lut(values) {}
+
+
+	public:
+		int size() const { return _size; }
+
+		Key lowerBound() const { return _lowerBound; }
+		Key upperBound() const { return _upperBound; }
+
+		void setRange(const Key &lower, const Key &upper) {
+			_lowerBound = lower;
+			_upperBound = upper;
+			_scale = (_size-1)/(upper-lower);
+		}
+
+		void setValue(int idx, const Value &v) {
+			if ( idx < 0 || idx >= _size ) return;
+			_lut[idx] = v;
+		}
+
+		const Value &valueAt(Key v) const {
+			int idx = (int)((v-_lowerBound)*_scale);
+			if ( idx < 0 ) idx = 0;
+			else if ( idx >= _size ) idx = _size-1;
+
+			return _lut[idx];
+		}
+
+		const Value &valueAtNormalizedIndex(Key v) const {
+			int idx = (int)(v*(_size-1));
+			if ( idx < 0 ) idx = 0;
+			else if ( idx >= _size ) idx = _size-1;
+
+			return _lut[idx];
+		}
+
+		Key indexToKey(int idx) const {
+			return idx / _scale + _lowerBound;
+		}
+
+
+	protected:
+		Key    _lowerBound;
+		Key    _upperBound;
+		Key    _scale;
+		int    _size;
+		Value *_lut;
+};
+
+
+template <typename Key, typename Value, int N>
+class StaticLUT : public LUT<Key,Value> {
+	public:
+		StaticLUT() : LUT<Key,Value>(N, _staticLUT) {}
+
+	protected:
+		Value _staticLUT[N];
+};
+
+
+template <int N>
+class StaticColorLUT : public StaticLUT<double, QRgb, N> {
+	public:
+		StaticColorLUT() {}
+		StaticColorLUT(const Gradient &gradient) {
+			generateFrom(gradient);
+		}
+
+	public:
+		bool setRangeFrom(const Gradient &gradient) {
+			if ( gradient.empty() ) return false;
+
+			double lower =  gradient.begin().key();
+			double upper = (--gradient.end()).key();
+			StaticLUT<double, QRgb, N>::setRange(lower, upper);
+
+			return true;
+		}
+
+		void generateFrom(const Gradient &gradient) {
+			if ( !setRangeFrom(gradient) ) return;
+			for ( int i = 0; i < N; ++i )
+				StaticLUT<double, QRgb, N>::_staticLUT[i] =
+					gradient.colorAt(StaticLUT<double, QRgb, N>::indexToKey(i)).rgba();
+		}
+};
+
+
+}
+}
+
+
+#endif

--- a/src/gui-qt4/libs/seiscomp3/gui/core/recordwidget.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/recordwidget.cpp
@@ -2010,59 +2010,84 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 
 	bool emitUpdated = false;
 
-	int streamHeight = h;
-	int streamYOffset = 0;
-	int streamYOffsetAddy = 0;
 	int slot;
-
-	Stream *stream = NULL;
 
 	switch ( _drawMode ) {
 		default:
 		case Single:
 		{
+			Stream *stream = NULL;
+
 			if ( (_currentSlot >= _streams.size() || _currentSlot < 0) || !_streams[_currentSlot]->visible )
 				stream = NULL;
-			else {
+			else
 				stream = _streams[_currentSlot];
 
+			for ( int i = 0; i < _streams.size(); ++i ) {
+				Stream *str = _streams[i];
+				if ( str == NULL ) continue;
+
+				if ( str == stream ) {
+					str->posY = 0;
+					str->height = h;
+				}
+				else {
+					str->posY = 0;
+					str->height = 0;
+				}
+			}
+
+			if ( stream != NULL ) {
 				if ( stream->hasCustomBackgroundColor )
-					painter.fillRect(0,streamYOffset,w,streamHeight, blend(bg, stream->customBackgroundColor));
+					painter.fillRect(0,stream->posY,w,stream->height, blend(bg, stream->customBackgroundColor));
 
 				if ( (stream->records[Stream::Filtered] && (stream->filtering || _showAllRecords) && stream->traces[Stream::Filtered].dirty) ||
 					(stream->records[Stream::Raw] && (!stream->filtering || _showAllRecords) && stream->traces[Stream::Raw].dirty) ) {
 					prepareRecords(stream);
-					drawRecords(stream, _currentSlot, streamHeight);
+					drawRecords(stream, _currentSlot, stream->height);
 					emitUpdated = true;
 				}
 			}
+
 			break;
 		}
 
 		case InRows:
 		{
 			int visibleSlots = 0;
+			int streamHeight = h;
+			int streamYOffset = 0;
+
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it )
 				if ( (*it)->visible ) ++visibleSlots;
 
 			if ( visibleSlots > 0 ) streamHeight /= visibleSlots;
 
-			streamYOffsetAddy = streamHeight;
 			slot = 0;
-			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it, ++slot, streamYOffset += streamYOffsetAddy ) {
-				stream = (*it)->visible?*it:NULL;
-				if ( stream == NULL ) continue;
+			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it, ++slot ) {
+				Stream *stream = *it;
+				if ( !stream->visible ) {
+					stream->posY = 0;
+					stream->height = 0;
+					continue;
+				}
+
+				stream->posY = streamYOffset;
+				stream->height = streamHeight;
 
 				if ( stream->hasCustomBackgroundColor )
-					painter.fillRect(0,streamYOffset,w,streamHeight, blend(bg, stream->customBackgroundColor));
+					painter.fillRect(0,stream->posY,w,stream->height, blend(bg, stream->customBackgroundColor));
 
 				if ( (stream->records[Stream::Filtered] && (stream->filtering || _showAllRecords) && stream->traces[Stream::Filtered].dirty) ||
 					(stream->records[Stream::Raw] && (!stream->filtering || _showAllRecords) && stream->traces[Stream::Raw].dirty) ) {
 					prepareRecords(stream);
-					drawRecords(stream, slot, streamHeight);
+					drawRecords(stream, slot, stream->height);
 					emitUpdated = true;
 				}
+
+				streamYOffset += streamHeight;
 			}
+
 			break;
 		}
 
@@ -2075,8 +2100,16 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 
 			// Two passes: First pass fetches the amplitude range and so on and scales all records appropriate
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it ) {
-				stream = (*it)->visible?*it:NULL;
-				if ( stream == NULL ) continue;
+				Stream *stream = *it;
+				if ( !stream->visible ) {
+					stream->posY = 0;
+					stream->height = 0;
+					continue;
+				}
+
+				stream->posY = 0;
+				stream->height = h;
+
 				if ( stream->hasCustomBackgroundColor &&
 					 !customBackgroundColor.isValid() )
 					customBackgroundColor = stream->customBackgroundColor;
@@ -2103,15 +2136,14 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 			}
 
 			if ( customBackgroundColor.isValid() )
-				painter.fillRect(0, streamYOffset, w, streamHeight,
-				                 blend(bg, customBackgroundColor));
+				painter.fillRect(0, 0, w, h, blend(bg, customBackgroundColor));
 
 			if ( !isDirty ) break;
 
 			// Second pass draws all records
 			slot = 0;
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it, ++slot ) {
-				stream = (*it)->visible?*it:NULL;
+				Stream *stream = (*it)->visible?*it:NULL;
 				if ( stream == NULL ) continue;
 
 				stream->traces[0].amplMin = minAmpl[0];
@@ -2120,7 +2152,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 				stream->traces[1].amplMin = minAmpl[1];
 				stream->traces[1].amplMax = maxAmpl[1];
 
-				drawRecords(stream, slot, streamHeight);
+				drawRecords(stream, slot, stream->height);
 				emitUpdated = true;
 			}
 			break;
@@ -2134,8 +2166,16 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 			QColor customBackgroundColor;
 			// Two passes: First pass fetches the amplitude range and so on and scales all records appropriate
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it ) {
-				stream = (*it)->visible?*it:NULL;
-				if ( stream == NULL ) continue;
+				Stream *stream = *it;
+				if ( !stream->visible ) {
+					stream->posY = 0;
+					stream->height = 0;
+					continue;
+				}
+
+				stream->posY = 0;
+				stream->height = h;
+
 				if ( stream->hasCustomBackgroundColor &&
 					 !customBackgroundColor.isValid() )
 					customBackgroundColor = stream->customBackgroundColor;
@@ -2165,8 +2205,8 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 			}
 
 			if ( customBackgroundColor.isValid() )
-				painter.fillRect(0,streamYOffset,w,streamHeight,
-								 blend(bg, customBackgroundColor));
+				painter.fillRect(0,0,w,h,
+				                 blend(bg, customBackgroundColor));
 
 			if ( !isDirty ) break;
 
@@ -2174,7 +2214,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 			// Second pass draws all records
 			slot = 0;
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it, ++slot ) {
-				stream = (*it)->visible?*it:NULL;
+				Stream *stream = (*it)->visible?*it:NULL;
 				if ( stream == NULL ) continue;
 
 				for ( int i = 0; i < 2; ++i ) {
@@ -2183,7 +2223,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					stream->traces[i].amplMax = stream->traces[i].offset + maxAmpl[j];
 				}
 
-				drawRecords(stream, slot, streamHeight);
+				drawRecords(stream, slot, stream->height);
 				emitUpdated = true;
 			}
 			break;
@@ -2197,14 +2237,16 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 
 	drawCustomBackground(painter);
 
+
 	// Draw gaps
 	switch ( _drawMode ) {
 		default:
 		case Stacked:
-			// In stacked mode only the gaps of the current slot are drawn
-			stream = (_currentSlot >= 0 && _currentSlot < _streams.size() && _streams[_currentSlot]->visible) ?
-				  _streams[_currentSlot] : NULL;
 		case Single:
+		{
+			Stream *stream = (_currentSlot >= 0 && _currentSlot < _streams.size() && _streams[_currentSlot]->visible) ?
+			                 _streams[_currentSlot] : NULL;
+
 			if ( stream ) {
 				int frontIndex = stream->filtering?Stream::Filtered:Stream::Raw;
 				if ( !stream->traces[frontIndex].poly.empty() ) {
@@ -2223,17 +2265,17 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					QColor overlapColor(blend(bg, SCScheme.colors.records.overlaps));
 					painter.setPen(fg);
 					painter.translate(QPoint(x_tmin[frontIndex], _tracePaintOffset));
-					stream->traces[frontIndex].poly.drawGaps(painter, 0, streamHeight, gapColor, overlapColor);
+					stream->traces[frontIndex].poly.drawGaps(painter, 0, stream->height, gapColor, overlapColor);
 					painter.translate(QPoint(-x_tmin[frontIndex], -_tracePaintOffset));
 				}
 			}
 			break;
+		}
 
 		case SameOffset:
 			break;
 
 		case InRows:
-			streamYOffset = 0;
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it ) {
 				Stream *stream = (*it)->visible?*it:NULL;
 				if ( stream == NULL ) continue;
@@ -2254,12 +2296,10 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					QColor gapColor(blend(bg, SCScheme.colors.records.gaps));
 					QColor overlapColor(blend(bg, SCScheme.colors.records.overlaps));
 					painter.setPen(fg);
-					painter.translate(QPoint(x_tmin[frontIndex], _tracePaintOffset + streamYOffset));
-					stream->traces[frontIndex].poly.drawGaps(painter, 0, streamHeight, gapColor, overlapColor);
-					painter.translate(QPoint(-x_tmin[frontIndex], -_tracePaintOffset - streamYOffset));
+					painter.translate(QPoint(x_tmin[frontIndex], _tracePaintOffset + stream->posY));
+					stream->traces[frontIndex].poly.drawGaps(painter, 0, stream->height, gapColor, overlapColor);
+					painter.translate(QPoint(-x_tmin[frontIndex], -_tracePaintOffset - stream->posY));
 				}
-
-				streamYOffset += streamYOffsetAddy;
 			}
 			break;
 	}
@@ -2292,14 +2332,9 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 	switch ( _drawMode ) {
 		default:
 		case Single:
-			for ( int i = 0; i < _streams.size(); ++i ) {
-				Stream *stream = _streams[i];
-				if ( stream == NULL ) continue;
-
-				stream->posY = streamYOffset;
-				stream->height = streamHeight;
-			}
-
+		{
+			Stream *stream = (_currentSlot >= 0 && _currentSlot < _streams.size() && _streams[_currentSlot]->visible) ?
+			                 _streams[_currentSlot] : NULL;
 			if ( stream ) {
 				double offset[2] = {0,0};
 				int x_tmin[2];
@@ -2340,9 +2375,9 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 				}
 			}
 			break;
+		}
 
 		case InRows:
-			streamYOffset = 0;
 			for ( int i = 0; i < _streams.size(); ++i ) {
 				Stream *stream = _streams[i]->visible?_streams[i]:NULL;
 				if ( stream == NULL ) continue;
@@ -2358,36 +2393,33 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 				x_tmin[0] = int(-(offset[0] + _tmin)*_pixelPerSecond);
 				x_tmin[1] = int(-(offset[1] + _tmin)*_pixelPerSecond);
 
-				if ( streamYOffsetAddy > 0 ) {
+				if ( stream->height > 0 ) {
 					// Enable clipping to rows if enabled
 					if ( _clipRows )
-						painter.setClipRect(QRect(0, streamYOffset, w, streamHeight));
+						painter.setClipRect(QRect(0, stream->posY, w, stream->height));
 					else
 						painter.setClipRect(QRect(0, 0, w, h));
 
 					if ( i == _currentSlot && _streams.size() > 1 ) {
 						painter.setBrush(Qt::NoBrush);
 						painter.setPen(QPen(palette().color(_enabled?QPalette::Active:QPalette::Disabled, QPalette::Text), 1, Qt::DashLine));
-						painter.drawRect(QRect(0, streamYOffset, w-1, streamHeight-1));
+						painter.drawRect(QRect(0, stream->posY, w-1, stream->height-1));
 					}
 				}
-
-				stream->posY = streamYOffset;
-				stream->height = streamHeight;
 
 				int frontIndex = stream->filtering?Stream::Filtered:Stream::Raw;
 				if ( !stream->traces[1-frontIndex].poly.empty() && _showAllRecords ) {
 					painter.setPen(gridColor[0]);
-					painter.translate(QPoint(x_tmin[1-frontIndex], _tracePaintOffset + streamYOffset));
+					painter.translate(QPoint(x_tmin[1-frontIndex], _tracePaintOffset + stream->posY));
 					//_trace[1-frontIndex].poly.translate(x_tmin[1-frontIndex], _tracePaintOffset);
 					stream->traces[1-frontIndex].poly.draw(painter);
-					painter.translate(QPoint(-x_tmin[1-frontIndex], -_tracePaintOffset - streamYOffset));
+					painter.translate(QPoint(-x_tmin[1-frontIndex], -_tracePaintOffset - stream->posY));
 				}
 
 				if ( !stream->traces[frontIndex].poly.empty() ) {
 					if ( _drawOffset ) {
 						painter.setPen(blend(bg, gridColor[0], 75));
-						painter.drawLine(0,_tracePaintOffset+stream->traces[frontIndex].poly.baseline() + streamYOffset, w,_tracePaintOffset+stream->traces[frontIndex].poly.baseline() + streamYOffset);
+						painter.drawLine(0,_tracePaintOffset+stream->traces[frontIndex].poly.baseline() + stream->posY, w,_tracePaintOffset+stream->traces[frontIndex].poly.baseline() + stream->posY);
 					}
 
 					if ( stream->antialiasing != isAntialiasing )
@@ -2397,12 +2429,10 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					if ( hMargin < 0 ) hMargin = 0;
 
 					painter.setPen(_enabled?stream->pen:fg);
-					painter.translate(QPoint(x_tmin[frontIndex], _tracePaintOffset + streamYOffset + hMargin));
+					painter.translate(QPoint(x_tmin[frontIndex], _tracePaintOffset + stream->posY + hMargin));
 					stream->traces[frontIndex].poly.draw(painter);
-					painter.translate(QPoint(-x_tmin[frontIndex], -_tracePaintOffset - streamYOffset - hMargin));
+					painter.translate(QPoint(-x_tmin[frontIndex], -_tracePaintOffset - stream->posY - hMargin));
 				}
-
-				streamYOffset += streamYOffsetAddy;
 			}
 			break;
 
@@ -2415,8 +2445,6 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					if ( stream == NULL ) continue;
 
 					int frontIndex = stream->filtering?Stream::Filtered:Stream::Raw;
-					stream->posY = streamYOffset;
-					stream->height = streamHeight;
 					if ( !stream->traces[frontIndex].poly.empty() ) {
 						painter.setPen(blend(bg, gridColor[0], 75));
 						painter.drawLine(0,_tracePaintOffset+stream->traces[frontIndex].poly.baseline(), w,_tracePaintOffset+stream->traces[frontIndex].poly.baseline());
@@ -2484,8 +2512,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 			break;
 	}
 
-	if ( streamYOffsetAddy > 0 )
-		painter.setClipRect(this->rect());
+	painter.setClipRect(this->rect());
 
 	if ( isAntialiasing )
 		painter.setRenderHint(QPainter::Antialiasing, false);
@@ -2577,6 +2604,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 		if ( m == _hoveredMarker ) {
 			QPen pen = painter.pen();
 			painter.setPen(QPen(palette().color(QPalette::Highlight), 1, Qt::DotLine));
+			painter.setBrush(Qt::NoBrush);
 			painter.drawRect(x-4, startY, 8, endY-startY+1);
 			painter.setPen(pen);
 		}
@@ -2584,6 +2612,7 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 		if ( m == activeMarker ) {
 			QPen pen = painter.pen();
 			painter.setPen(QPen(palette().color(QPalette::Text), 1, Qt::DashLine));
+			painter.setBrush(Qt::NoBrush);
 			painter.drawRect(x-4, startY, 8, endY-startY+1);
 			painter.setPen(pen);
 		}
@@ -2596,6 +2625,10 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 	switch ( _drawMode ) {
 		default:
 		case Single:
+		{
+			Stream *stream = (_currentSlot >= 0 && _currentSlot < _streams.size() && _streams[_currentSlot]->visible) ?
+			                 _streams[_currentSlot] : NULL;
+
 			if ( stream ) {
 				int frontIndex = stream->filtering?Stream::Filtered:Stream::Raw;
 				if ( !stream->traces[frontIndex].poly.empty() ) {
@@ -2611,12 +2644,12 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 							str.setNum(stream->traces[frontIndex].absMax, 'f', _valuePrecision);
 
 						int rh = 2*painter.fontMetrics().ascent()+4;
-						int y = streamHeight - rh;
+						int y = stream->height - rh;
 						if  ( y < 0 ) y = 0;
 
 						painter.drawText(0,y, w,rh, Qt::TextSingleLine | Qt::AlignLeft | Qt::AlignTop, str);
 
-						if ( streamHeight >= y+rh ) {
+						if ( stream->height >= y+rh ) {
 							if ( _showScaledValues )
 								str.setNum(stream->traces[frontIndex].offset*stream->scale);
 							else
@@ -2649,9 +2682,9 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 				}
 			}
 			break;
+		}
 
 		case InRows:
-			streamYOffset = 0;
 			for ( StreamMap::iterator it = _streams.begin(); it != _streams.end(); ++it ) {
 				Stream *stream = (*it)->visible?*it:NULL;
 				if ( stream == NULL ) continue;
@@ -2670,12 +2703,12 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 							str.setNum(stream->traces[frontIndex].absMax, 'f', _valuePrecision);
 
 						int rh = 2*painter.fontMetrics().ascent()+4;
-						int y = streamYOffset + streamHeight - rh;
-						if ( y < streamYOffset ) y = streamYOffset;
+						int y = stream->posY + stream->height - rh;
+						if ( y < stream->posY ) y = stream->posY;
 
 						painter.drawText(0,y, w,rh, Qt::TextSingleLine | Qt::AlignLeft | Qt::AlignTop, str);
 
-						if ( streamYOffset+streamHeight >= y+rh ) {
+						if ( stream->posY+stream->height >= y+rh ) {
 							if ( _showScaledValues )
 								str.setNum(stream->traces[frontIndex].offset*stream->scale);
 							else
@@ -2692,13 +2725,11 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 					QRect br = painter.fontMetrics().boundingRect(stream->id);
 					br.adjust(0,0,4,4);
 					//br.moveCenter(QPoint(br.center().x(), streamHeight/2+streamYOffset));
-					br.moveTopLeft(QPoint(0,streamYOffset));
+					br.moveTopLeft(QPoint(0,stream->posY));
 					painter.fillRect(br, bg);
 					painter.drawRect(br);
 					painter.drawText(br, Qt::AlignCenter, stream->id);
 				}
-
-				streamYOffset += streamHeight;
 			}
 			break;
 
@@ -2742,12 +2773,12 @@ void RecordWidget::paintEvent(QPaintEvent *event) {
 						str.setNum(absMax, 'f', _valuePrecision);
 
 					int rh = 2*painter.fontMetrics().ascent()+4;
-					int y = streamHeight - rh;
+					int y = stream->height - rh;
 					if ( y < 0 ) y = 0;
 
 					painter.drawText(0,y, w,rh, Qt::TextSingleLine | Qt::AlignLeft | Qt::AlignTop, str);
 
-					if ( streamHeight >= y+rh ) {
+					if ( stream->height >= y+rh ) {
 						if ( _showScaledValues )
 							str.setNum(offset*stream->scale);
 						else

--- a/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.cpp
@@ -445,7 +445,7 @@ void SpectrogramRenderer::fillRow(QImage &img, Seiscomp::ComplexDoubleArray *spe
 			double logRange = logTo - logFrom;
 
 			for ( int i = n; i; --i ) {
-				double li = exp10((i-1)*logRange/(n-1) + logFrom) - 1;
+				double li = pow(10.0, (i-1)*logRange/(n-1) + logFrom) - 1;
 				int i0 = (int)li;
 				double t = li-i0;
 
@@ -489,7 +489,7 @@ void SpectrogramRenderer::fillRow(QImage &img, Seiscomp::ComplexDoubleArray *spe
 			double logRange = logTo - logFrom;
 
 			for ( int i = n; i; --i ) {
-				double li = exp10((i-1)*logRange/(n-1) + logFrom) - 1;
+				double li = pow(10.0, (i-1)*logRange/(n-1) + logFrom) - 1;
 				int i0 = (int)li;
 				double t = li-i0;
 
@@ -807,7 +807,7 @@ void SpectrogramRenderer::renderAxis(QPainter &p, const QRect &rect, bool leftAl
 	double yPos = 0;
 
 	for ( int i = 0; i <= steps; ++i, yPos += vSpacing, f -= fSpacing ) {
-		int y = axis.top() + (int)(_logarithmic ? exp10(yPos) : yPos);
+		int y = axis.top() + (int)(_logarithmic ? pow(10.0, yPos) : yPos);
 		if ( y > axis.bottom() ) y = axis.bottom();
 		p.drawLine(xPos, y, xPos+4, y);
 

--- a/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.cpp
@@ -1,0 +1,842 @@
+/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#include <seiscomp3/gui/core/spectrogramrenderer.h>
+
+
+namespace Seiscomp {
+namespace Gui {
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+SpectrogramRenderer::SpectrogramRenderer() {
+	_tmin = _tmax = 0;
+	_scale = 1.0;
+	_ampMin = -15;
+	_ampMax = -5;
+	_imageFormat = QImage::Format_RGB32;
+
+	Gradient gradient;
+	gradient.setColorAt(0.0, QColor(255,   0, 255)); // pink
+	gradient.setColorAt(0.2, QColor(  0,   0, 255)); // blue
+	gradient.setColorAt(0.4, QColor(  0, 255, 255)); // cyan
+	gradient.setColorAt(0.6, QColor(  0, 255,   0)); // green
+	gradient.setColorAt(0.8, QColor(255, 255,   0)); // yellow
+	gradient.setColorAt(1.0, QColor(255,   0,   0)); // red
+
+	setGradient(gradient);
+
+	_normalize = false;
+	_logarithmic = false;
+	_dirty = false;
+
+	_renderedFmin = _renderedFmax = -1;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setGradient(const Gradient &gradient) {
+	Gradient::const_iterator it;
+	bool hasAlphaChannel = false;
+
+	for ( it = gradient.begin(); it != gradient.end(); ++it ) {
+		if ( it.value().first.alpha() < 255 ) {
+			hasAlphaChannel = true;
+			break;
+		}
+	}
+
+	_imageFormat = hasAlphaChannel ? QImage::Format_ARGB32 : QImage::Format_RGB32;
+
+	_gradient.generateFrom(gradient);
+	_gradient.setRange(_ampMin, _ampMax);
+
+	setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramRenderer::setOptions(const IO::Spectralizer::Options &opts) {
+	if ( !_spectralizer )
+		_spectralizer = new IO::Spectralizer;
+
+	// Reset data
+	reset();
+
+	_options = opts;
+	return _spectralizer->setOptions(_options);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setScale(double scale) {
+	_scale = scale;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setGradientRange(double lowerBound, double upperBound) {
+	_ampMin = lowerBound;
+	_ampMax = upperBound;
+
+	_gradient.setRange(lowerBound, upperBound);
+
+	if ( !_spectralizer ) return;
+
+	setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::reset() {
+	if ( !_spectralizer ) return;
+
+	_spectra.clear();
+	_images.clear();
+
+	_spectralizer = new IO::Spectralizer;
+	_spectralizer->setOptions(_options);
+
+	_renderedFmin = _renderedFmax = -1;
+
+	setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramRenderer::feed(const Record *rec) {
+	if ( !_spectralizer ) return false;
+
+	// Record clipped
+	if ( _timeWindow.startTime().valid() && rec->endTime() <= _timeWindow.startTime() )
+		return false;
+
+	// Record clipped
+	if ( _timeWindow.endTime().valid() && rec->startTime() >= _timeWindow.endTime() )
+		return false;
+
+	if ( _spectralizer->push(rec) ) {
+		IO::SpectrumPtr spec;
+
+		while ( (spec = _spectralizer->pop()) ) {
+			if ( !spec->isValid() ) continue;
+
+			// Deconvolution
+			if ( _transferFunction ) {
+				Seiscomp::ComplexDoubleArray *data = spec->data();
+				double df = spec->maximumFrequency() / data->size();
+				_transferFunction->deconvolve(data->impl(), df, df);
+			}
+
+			_spectra.push_back(spec);
+			addSpectrum(spec.get());
+			setDirty();
+		}
+	}
+
+	return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramRenderer::feedSequence(const RecordSequence *seq) {
+	if ( seq == NULL ) return true;
+
+	RecordSequence::const_iterator it;
+	bool result = false;
+	for ( it = seq->begin(); it != seq->end(); ++it )
+		if ( feed(it->get()) ) result = true;
+
+	setDirty();
+
+	return result;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setRecords(const RecordSequence *seq) {
+	reset();
+	feedSequence(seq);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setAlignment(const Core::Time &align) {
+	_alignment = align;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setTimeRange(double tmin, double tmax) {
+	_tmin = tmin;
+	_tmax = tmax;
+
+	if ( _tmin > _tmax )
+		std::swap(_tmin, _tmax);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setTimeWindow(const Core::TimeWindow& tw) {
+	_timeWindow = tw;
+
+	// Trim spectra
+	if ( _timeWindow.startTime().valid() || _timeWindow.endTime().valid() ) {
+		Spectra::iterator it;
+		bool needUpdate = false;
+
+		for ( it = _spectra.begin(); it != _spectra.end(); ) {
+			IO::Spectrum *spec = it->get();
+			if ( _timeWindow.startTime().valid() && spec->endTime() <= _timeWindow.startTime() ) {
+				it = _spectra.erase(it);
+				needUpdate = true;
+			}
+			else if ( _timeWindow.endTime().valid() && spec->startTime() >= _timeWindow.endTime() ) {
+				it = _spectra.erase(it);
+				needUpdate = true;
+			}
+			else
+				++it;
+		}
+
+		if ( needUpdate ) setDirty();
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setFrequencyRange(OPT(double) fmin, OPT(double) fmax) {
+	_fmin = fmin;
+	_fmax = fmax;
+
+	if ( _normalize ) setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setNormalizeAmplitudes(bool f) {
+	if ( _normalize == f ) return;
+	_normalize = f;
+
+	if ( !_spectralizer ) return;
+
+	setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setLogScale(bool f) {
+	if ( _logarithmic == f ) return;
+	_logarithmic = f;
+
+	if ( !_spectralizer ) return;
+
+	setDirty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setTransferFunction(Math::Restitution::FFT::TransferFunction *tf) {
+	_transferFunction = tf;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::setDirty() {
+	_dirty = true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::renderSpectrogram() {
+	Spectra::iterator it;
+
+	_images.clear();
+
+	for ( it = _spectra.begin(); it != _spectra.end(); ++it )
+		addSpectrum(it->get());
+
+	_dirty = false;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::addSpectrum(IO::Spectrum *spec) {
+	Seiscomp::ComplexDoubleArray *data = spec->data();
+
+	if ( _images.empty() ) {
+		SpecImage img;
+		img.minimumFrequency = spec->minimumFrequency();
+		img.maximumFrequency = spec->maximumFrequency();
+		img.startTime = spec->center();
+		img.dt = spec->dt();
+
+		img.data = QImage(1, data->size(), _imageFormat);
+
+		fillRow(img.data, data, spec->maximumFrequency(), 0);
+
+		_images.append(img);
+	}
+	else {
+		SpecImage &img = _images.back();
+		Core::Time newTime = spec->center();
+
+		// Do more checks on gaps and so on
+
+		double dt = (double)img.dt;
+		Core::Time currentEndTime = img.startTime + Core::TimeSpan(img.data.width()*dt);
+
+		bool needNewImage = (fabs((double)(newTime - currentEndTime)) > dt*0.5)
+		                 || (img.data.height() != data->size())
+		                 || (img.minimumFrequency != spec->minimumFrequency())
+		                 || (img.maximumFrequency != spec->maximumFrequency())
+		                 || (img.dt != spec->dt());
+
+		// Gap, overlap or different meta data -> start new image
+		if ( needNewImage ) {
+			SpecImage newImg;
+			newImg.minimumFrequency = spec->minimumFrequency();
+			newImg.maximumFrequency = spec->maximumFrequency();
+			newImg.startTime = spec->center();
+			newImg.dt = spec->dt();
+
+			newImg.data = QImage(1, data->size(), _imageFormat);
+			fillRow(newImg.data, data, spec->maximumFrequency(), 0);
+
+			_images.append(newImg);
+		}
+		else {
+			// Extent image by one column
+			int col = img.data.width();
+			img.data = img.data.copy(0,0,col+1,img.data.height());
+
+			// Fill colors for column
+			fillRow(img.data, data, spec->maximumFrequency(), col);
+		}
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::fillRow(QImage &img, Seiscomp::ComplexDoubleArray *spec,
+                                  double maxFreq, int column) {
+	QRgb *rgb = (QRgb*)img.bits();
+	int ofs = img.width();
+	int n = spec->size();
+
+	// Goto nth column
+	rgb += column;
+
+	if ( _normalize ) {
+		double amin = -1, amax = -1;
+		double fmin = 0.0, fmax = maxFreq;
+		if ( _fmin ) fmin = *_fmin;
+		if ( _fmax ) fmax = *_fmax;
+
+		// Compute min/max amplitude
+		double f = maxFreq;
+		double df = maxFreq / spec->size();
+
+		for ( int i = n; i; --i, f -= df ) {
+			if ( f < fmin || f > fmax ) continue;
+
+			Seiscomp::ComplexDoubleArray::Type &v = (*spec)[i-1];
+
+			double sr = v.real()*_scale;
+			double si = v.imag()*_scale;
+			double ps = sr*sr + si*si;
+			if ( ps > 0 ) {
+				if ( amin < 0 || amin > ps )
+					amin = ps;
+				if ( amax < 0 || amax < ps )
+					amax = ps;
+			}
+		}
+
+		double ascale = 1.0;
+
+		if ( amin > 0 && amax > 0 ) {
+			amin = log10(amin);
+			amax = log10(amax);
+
+			double arange = amax-amin;
+			if ( arange > 0 )
+				ascale = 1.0/arange;
+		}
+		else {
+			amin = 0;
+			ascale = 0;
+		}
+
+		if ( _logarithmic ) {
+			double logTo = log10(n);
+			double logFrom = 0;
+			double logRange = logTo - logFrom;
+
+			for ( int i = n; i; --i ) {
+				double li = exp10((i-1)*logRange/(n-1) + logFrom) - 1;
+				int i0 = (int)li;
+				double t = li-i0;
+
+				Seiscomp::ComplexDoubleArray::Type v;
+
+				if ( t == 0 )
+					v = (*spec)[i0];
+				else
+					v = (*spec)[i0]*(1-t)+(*spec)[i0+1]*t;
+
+				double sr = v.real()*_scale;
+				double si = v.imag()*_scale;
+				double ps = sr*sr + si*si;
+				double amp = ps > 0?log10(ps):_gradient.lowerBound();
+				amp = (amp-amin)*ascale;
+
+				*rgb = _gradient.valueAtNormalizedIndex(amp);
+				rgb += ofs;
+			}
+		}
+		else {
+			for ( int i = n; i; --i ) {
+				Seiscomp::ComplexDoubleArray::Type &v = (*spec)[i-1];
+
+				double sr = v.real()*_scale;
+				double si = v.imag()*_scale;
+				double ps = sr*sr + si*si;
+				double amp = ps > 0?log10(ps):_gradient.lowerBound();
+				amp = (amp-amin)*ascale;
+
+				*rgb = _gradient.valueAtNormalizedIndex(amp);
+				rgb += ofs;
+			}
+		}
+	}
+	else {
+		// Go from highest to lowest frequency
+		if ( _logarithmic ) {
+			double logTo = log10(n);
+			double logFrom = 0;
+			double logRange = logTo - logFrom;
+
+			for ( int i = n; i; --i ) {
+				double li = exp10((i-1)*logRange/(n-1) + logFrom) - 1;
+				int i0 = (int)li;
+				double t = li-i0;
+
+				Seiscomp::ComplexDoubleArray::Type v;
+
+				if ( t == 0 )
+					v = (*spec)[i0];
+				else
+					v = (*spec)[i0]*(1-t)+(*spec)[i0+1]*t;
+
+				double sr = v.real()*_scale;
+				double si = v.imag()*_scale;
+				double ps = sr*sr + si*si;
+				double amp = ps > 0?log10(ps):_gradient.lowerBound();
+
+				*rgb = _gradient.valueAt(amp);
+				rgb += ofs;
+			}
+		}
+		else {
+			for ( int i = n; i; --i ) {
+				Seiscomp::ComplexDoubleArray::Type &v = (*spec)[i-1];
+
+				double sr = v.real()*_scale;
+				double si = v.imag()*_scale;
+				double ps = sr*sr + si*si;
+				double amp = ps > 0?log10(ps):_gradient.lowerBound();
+
+				*rgb = _gradient.valueAt(amp);
+				rgb += ofs;
+			}
+		}
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::render(QPainter &p, const QRect &rect,
+                                 bool labelLeftAlign, bool renderLabels) {
+	SpecImageList::iterator it;
+	double fmin = -1;
+	double fmax = -1;
+	double frange;
+
+	_renderedFmin = fmin;
+	_renderedFmax = fmax;
+
+	int w = rect.width();
+	int h = rect.height();
+
+	if ( (h <= 0) || (w <= 0) ) return;
+
+	if ( _dirty ) renderSpectrogram();
+	if ( _images.empty() ) return;
+
+	if ( !_fmax ) {
+		bool first = true;
+		for ( it = _images.begin(); it != _images.end(); ++ it ) {
+			if ( first ) {
+				fmax = it->maximumFrequency;
+				first = false;
+			}
+			else if ( it->maximumFrequency > fmax )
+				fmax = it->maximumFrequency;
+		}
+	}
+	else
+		fmax = *_fmax;
+
+	if ( !_fmin ) {
+		bool first = true;
+		for ( it = _images.begin(); it != _images.end(); ++ it ) {
+			if ( first ) {
+				fmin = it->minimumFrequency;
+				first = false;
+			}
+			else if ( it->minimumFrequency < fmin )
+				fmin = it->minimumFrequency;
+		}
+	}
+	else
+		fmin = *_fmin;
+
+	if ( fmin > fmax ) std::swap(fmin, fmax);
+
+	frange = fmax - fmin;
+
+	_renderedFmin = fmin;
+	_renderedFmax = fmax;
+
+	Core::Time t0 = _alignment + Core::TimeSpan(_tmin);
+	Core::Time t1 = _alignment + Core::TimeSpan(_tmax);
+	double xlen = t1-t0;
+
+	// Nothing to draw
+	if ( xlen <= 0 ) return;
+
+	double dx = 1.0/xlen;
+
+	p.save();
+	p.setRenderHint(QPainter::SmoothPixmapTransform);
+
+	// Draw images
+	for ( it = _images.begin(); it != _images.end(); ++ it ) {
+		SpecImage &img = *it;
+
+		// Clip by min frequency
+		if ( img.minimumFrequency >= fmax ) continue;
+
+		// Clip by max frequency
+		if ( img.maximumFrequency <= fmin ) continue;
+
+		Core::Time startTime = img.startTime - Core::TimeSpan((double)img.dt*0.5);
+		Core::Time endTime   = startTime + Core::TimeSpan((double)img.dt * img.data.width());
+
+		// Clip by start time
+		if ( startTime >= t1 ) continue;
+
+		// Clip by end time
+		if ( endTime <= t0 ) continue;
+
+		double x0 = startTime - t0;
+		double x1 = endTime - t0;
+
+		double ifw = img.maximumFrequency-img.minimumFrequency;
+
+		// Convert start and end time into widget coordinates
+		int ix0 = (int)(x0*dx*w);
+		int ix1 = (int)(x1*dx*w);
+
+		// Source lines to plot
+		int sy0 = 0;
+		int sy1 = img.data.height();
+
+		int ty0 = 0;
+		int ty1 = h;
+
+		if ( _logarithmic ) {
+			if ( fmin < img.minimumFrequency )
+				ty0 = (int)(log10(((img.minimumFrequency-fmin)/frange)*h)/log(h)*h);
+			else
+				sy0 = (int)(log10(((fmin-img.minimumFrequency)/ifw)*img.data.height())/log10(img.data.height())*img.data.height());
+
+			if ( fmax > img.maximumFrequency )
+				ty1 = (int)(log10((1.0-(fmax-img.maximumFrequency)/frange)*h)/log10(h)*h);
+			else
+				sy1 = (int)(log10((1.0-(img.maximumFrequency-fmax)/ifw)*img.data.height())/log10(img.data.height())*img.data.height());
+		}
+		else {
+			if ( fmin < img.minimumFrequency )
+				ty0 = (int)((img.minimumFrequency-fmin)/frange * h);
+			else
+				sy0 = (int)((fmin-img.minimumFrequency)/ifw * img.data.height());
+
+			if ( fmax > img.maximumFrequency )
+				ty1 = (int)((1.0-(fmax-img.maximumFrequency)/frange) * h);
+			else
+				sy1 = (int)((1.0-(img.maximumFrequency-fmax)/ifw) * img.data.height());
+		}
+
+		QRect sourceRect(0,img.data.height()-sy1,img.data.width(),sy1-sy0),
+		      targetRect(rect.left()+ix0,rect.top()+h-ty1,ix1-ix0,ty1-ty0);
+
+		p.drawImage(targetRect, img.data, sourceRect);
+	}
+
+	if ( renderLabels && (fmin >= 0) && (fmax >= 0) ) {
+		QFont font = p.font();
+		QFontInfo fi(font);
+		int fontSize = std::min(h/2, fi.pixelSize());
+
+		font.setPixelSize(fontSize);
+
+		p.setFont(font);
+
+		QString minFreq = QString("%1Hz").arg(fmin);
+		QString maxFreq = QString("%1Hz").arg(fmax);
+
+		QRect minR = p.fontMetrics().boundingRect(minFreq);
+		QRect maxR = p.fontMetrics().boundingRect(maxFreq);
+
+		minR.adjust(-2,-2,2,2);
+		maxR.adjust(-2,-2,2,2);
+
+		if ( labelLeftAlign )
+			minR.moveBottomLeft(rect.bottomLeft()-QPoint(0,1));
+		else
+			minR.moveBottomRight(rect.bottomRight()-QPoint(0,1));
+
+		p.drawRect(minR);
+		p.drawText(minR, Qt::AlignCenter, minFreq);
+
+		if ( labelLeftAlign )
+			maxR.moveTopLeft(rect.topLeft());
+		else
+			maxR.moveTopRight(rect.topRight());
+
+		p.drawRect(maxR);
+		p.drawText(maxR, Qt::AlignCenter, maxFreq);
+	}
+
+	p.restore();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramRenderer::renderAxis(QPainter &p, const QRect &rect, bool leftAlign) {
+	if ( (_renderedFmin < 0) || (_renderedFmax < 0) ) return;
+
+	int w = rect.width();
+	int h = rect.height();
+
+	if ( (h <= 0) || (w <= 0) ) return;
+
+	QFont font = p.font();
+	QFontInfo fi(font);
+	int fontSize = std::min(h/2, fi.pixelSize());
+
+	font.setPixelSize(fontSize);
+
+	p.setFont(font);
+
+	double frange = _renderedFmax - _renderedFmin;
+
+	QString minFreq = QString("%1").arg(_renderedFmin);
+	QString maxFreq = QString("%1").arg(_renderedFmax);
+
+	QRect minR = p.fontMetrics().boundingRect(minFreq);
+	QRect maxR = p.fontMetrics().boundingRect(maxFreq);
+
+	QString axisLabel = "f [1/T] in Hz";
+	QRect axisLabelR = p.fontMetrics().boundingRect(axisLabel);
+
+	if ( axisLabelR.width() >= h-4 ) {
+		axisLabel = "Hz";
+		axisLabelR = p.fontMetrics().boundingRect(axisLabel);
+	}
+
+	minR.adjust(0,-1,0,1);
+	maxR.adjust(0,-1,0,1);
+
+	int wAxis = std::max(minR.width(), maxR.width()) + 6;
+	QRect axis(0,0,wAxis,h), area;
+
+	if ( leftAlign ) {
+		axis.moveTopLeft(rect.topLeft());
+		axis.translate(axisLabelR.height()+2,0);
+		area = axis.adjusted(-axisLabelR.height()-2,0,0,0);
+	}
+	else {
+		axis.moveTopRight(rect.topRight());
+		axis.translate(-axisLabelR.height()-2,0);
+		area = axis.adjusted(0,0,axisLabelR.height()+2,0);
+	}
+
+	p.fillRect(area, p.brush());
+
+	if ( leftAlign )
+		p.drawLine(axis.topRight(), axis.bottomRight());
+	else
+		p.drawLine(axis.topLeft(), axis.bottomLeft());
+
+	p.save();
+	p.translate(area.right()-2, area.center().y()+axisLabelR.width()/2);
+	p.rotate(-90);
+	p.drawText(axisLabelR, Qt::AlignHCenter | Qt::AlignTop, axisLabel);
+	p.restore();
+
+	if ( leftAlign ) {
+		p.drawText(axis.adjusted(0,0,-6,0), Qt::AlignRight | Qt::AlignTop, maxFreq);
+		p.drawText(axis.adjusted(0,0,-6,0), Qt::AlignRight | Qt::AlignBottom, minFreq);
+	}
+	else {
+		p.drawText(axis.adjusted(6,0,0,0), Qt::AlignLeft | Qt::AlignTop, maxFreq);
+		p.drawText(axis.adjusted(6,0,0,0), Qt::AlignLeft | Qt::AlignBottom, minFreq);
+	}
+
+	// Reduce axis rect to free area
+	QRect labels = axis.adjusted(0,maxR.height()-2,0,-minR.height()-2);
+	if ( leftAlign )
+		labels.adjust(0,0,-6,0);
+	else
+		labels.adjust(6,0,0,0);
+
+	int steps = 10;
+	double vSpacing;
+
+	if ( _logarithmic ) {
+		vSpacing = double(log10(axis.height())) / steps;
+	}
+	else {
+		vSpacing = double(axis.height()) / steps;
+		if ( vSpacing < 4 ) {
+			steps = 5;
+			vSpacing = double(axis.height()) / steps;
+		}
+	}
+
+	double fSpacing = frange / steps;
+
+	int xPos = leftAlign ? axis.right()-4 : axis.left();
+
+	p.save();
+	p.setBrush(Qt::NoBrush);
+
+	int alignmentFlags = (leftAlign ? Qt::AlignRight : Qt::AlignLeft) | Qt::AlignVCenter;
+
+	double f = _renderedFmax;
+	double yPos = 0;
+
+	for ( int i = 0; i <= steps; ++i, yPos += vSpacing, f -= fSpacing ) {
+		int y = axis.top() + (int)(_logarithmic ? exp10(yPos) : yPos);
+		if ( y > axis.bottom() ) y = axis.bottom();
+		p.drawLine(xPos, y, xPos+4, y);
+
+		// Try to render label
+		QString freq = QString("%1").arg(f);
+		QRect freqR = p.fontMetrics().boundingRect(freq);
+		freqR.adjust(0,1,0,1);
+
+		if ( leftAlign )
+			freqR.moveRight(labels.right());
+		else
+			freqR.moveLeft(labels.left());
+
+		freqR.moveTop(y-freqR.height()/2);
+
+		if ( labels.contains(freqR) ) {
+			p.drawText(freqR, alignmentFlags, freq);
+			// Shrink the labels area
+			labels.setTop(freqR.bottom());
+		}
+	}
+
+	p.restore();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+}
+}

--- a/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.h
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramrenderer.h
@@ -1,0 +1,162 @@
+/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#ifndef __SEISCOMP_GUI_CORE_SPECTROGRAMRENDERER_H__
+#define __SEISCOMP_GUI_CORE_SPECTROGRAMRENDERER_H__
+
+
+#include <seiscomp3/core/recordsequence.h>
+#include <seiscomp3/math/restitution/transferfunction.h>
+#include <seiscomp3/io/recordfilter/spectralizer.h>
+#include <seiscomp3/gui/core/lut.h>
+
+#include <QPainter>
+
+
+namespace Seiscomp {
+namespace Gui {
+
+
+class SC_GUI_API SpectrogramRenderer {
+	// ----------------------------------------------------------------------
+	//  Public types
+	// ----------------------------------------------------------------------
+	public:
+		SpectrogramRenderer();
+
+
+	// ----------------------------------------------------------------------
+	//  Public Interface
+	// ----------------------------------------------------------------------
+	public:
+		//! Sets the spectrogram options and calls reset().
+		bool setOptions(const IO::Spectralizer::Options &opts);
+		const IO::Spectralizer::Options &options() const { return _options; }
+
+		//! Sets the scale of the raw stream data which is 1/gain to convert
+		//! to sensor units
+		void setScale(double scale);
+
+		//! Sets the color gradient. Key range is normalized to [0,1].
+		void setGradient(const Gradient &gradient);
+
+		//! Sets the gradient range
+		void setGradientRange(double lowerBound, double upperBound);
+
+		double gradientLowerBound() const { return _gradient.lowerBound(); }
+		double gradientUpperBound() const { return _gradient.upperBound(); }
+
+		//! Resets the spectrogram and deletes all data
+		void reset();
+
+		//! Feeds a record for processing. Records must be timely ordered
+		//! otherwise gaps are produced.
+		bool feed(const Record *rec);
+		bool feedSequence(const RecordSequence *seq);
+
+		//! Resets the view and feeds the sequence
+		void setRecords(const RecordSequence *seq);
+
+		void setAlignment(const Core::Time &align);
+		void setTimeRange(double tmin, double tmax);
+
+		//! Sets the current time window of the data
+		void setTimeWindow(const Core::TimeWindow &tw);
+
+		//! Sets the frequency range to be displayed. A value lower or equal to
+		//! zero refers to the global minimum or the global maximum
+		//! respectively.
+		void setFrequencyRange(OPT(double) fmin, OPT(double) fmax);
+
+		const OPT(double) &frequencyLowerBound() const { return _fmin; }
+		const OPT(double) &frequencyUpperBound() const { return _fmax; }
+
+		void setNormalizeAmplitudes(bool f);
+		bool normalizeAmplitudes() const { return _normalize; }
+
+		void setLogScale(bool f);
+		bool logScale() const { return _logarithmic; }
+
+		//! Sets the transfer function for deconvolution
+		void setTransferFunction(Math::Restitution::FFT::TransferFunction *tf);
+
+		bool isDirty() const { return _dirty; }
+
+		//! Creates the spectrogram. This is usually done in render if the
+		//! spectrogram is dirty but can called from outside.
+		void renderSpectrogram();
+
+		//! Renders the spectrogram with the given painter into the given rect.
+		void render(QPainter &p, const QRect &rect, bool labelLeftAlign = true,
+		            bool renderLabels = false);
+
+		//! Renders the y axis. This call must precede a call to render otherwise
+		//! the frequency range can by out of sync.
+		void renderAxis(QPainter &p, const QRect &rect, bool leftAlign = true);
+
+
+	// ----------------------------------------------------------------------
+	//  Private Interface
+	// ----------------------------------------------------------------------
+	private:
+		void setDirty();
+		void addSpectrum(IO::Spectrum *);
+		void fillRow(QImage &img, Seiscomp::ComplexDoubleArray *spec,
+		             double maxFreq, int column);
+
+
+	// ----------------------------------------------------------------------
+	//  Private members
+	// ----------------------------------------------------------------------
+	private:
+		typedef QList<IO::SpectrumPtr> Spectra;
+
+		struct SpecImage {
+			QImage         data;
+			Core::Time     startTime;
+			Core::TimeSpan dt;
+			double         minimumFrequency;
+			double         maximumFrequency;
+		};
+
+		typedef QList<SpecImage> SpecImageList;
+		typedef StaticColorLUT<512> Gradient512;
+		typedef Math::Restitution::FFT::TransferFunctionPtr TransferFunctionPtr;
+
+		QImage::Format            _imageFormat;
+		TransferFunctionPtr       _transferFunction;
+		Core::TimeWindow          _timeWindow;
+		Core::Time                _alignment;
+		double                    _tmin, _tmax;
+		double                    _scale;
+		OPT(double)               _fmin, _fmax;
+		double                    _ampMin, _ampMax;
+		IO::Spectralizer::Options _options;
+		IO::SpectralizerPtr       _spectralizer;
+		Spectra                   _spectra;
+		SpecImageList             _images;
+		Gradient512               _gradient;
+		bool                      _normalize;
+		bool                      _logarithmic;
+		bool                      _dirty;
+		double                    _renderedFmin;
+		double                    _renderedFmax;
+};
+
+
+}
+}
+
+
+#endif

--- a/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramwidget.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramwidget.cpp
@@ -1,0 +1,261 @@
+/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#include <seiscomp3/gui/core/spectrogramwidget.h>
+
+
+namespace Seiscomp {
+namespace Gui {
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+SpectrogramWidget::SpectrogramWidget(QWidget *parent, Qt::WindowFlags f)
+: QWidget(parent, f) {}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramWidget::setSpectrumOptions(const SpectrumOptions &opts) {
+	return _renderer.setOptions(opts);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const SpectrogramWidget::SpectrumOptions &SpectrogramWidget::spectrumOptions() const {
+	return _renderer.options();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setScale(double scale) {
+	_renderer.setScale(scale);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setGradientRange(double lowerBound, double upperBound) {
+	_renderer.setGradientRange(lowerBound, upperBound);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+double SpectrogramWidget::gradientLowerBound() const {
+	return _renderer.gradientLowerBound();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+double SpectrogramWidget::gradientUpperBound() const {
+	return _renderer.gradientUpperBound();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::reset() {
+	_renderer.reset();
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramWidget::feed(const Record *rec) {
+	return _renderer.feed(rec);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramWidget::feedSequence(const RecordSequence *seq) {
+	return _renderer.feedSequence(seq);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setRecords(const RecordSequence *seq) {
+	_renderer.setRecords(seq);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setAlignment(const Core::Time &align) {
+	_renderer.setAlignment(align);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setTimeRange(double tmin, double tmax) {
+	_renderer.setTimeRange(tmin, tmax);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setTimeWindow(const Core::TimeWindow &tw) {
+	_renderer.setTimeWindow(tw);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setFrequencyRange(OPT(double) fmin, OPT(double) fmax) {
+	_renderer.setFrequencyRange(fmin, fmax);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const OPT(double) &SpectrogramWidget::frequencyLowerBound() const {
+	return _renderer.frequencyLowerBound();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const OPT(double) &SpectrogramWidget::frequencyUpperBound() const {
+	return _renderer.frequencyUpperBound();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setNormalizeAmplitudes(bool f) {
+	_renderer.setNormalizeAmplitudes(f);
+	update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramWidget::normalizeAmplitudes() const {
+	return _renderer.normalizeAmplitudes();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setLogScale(bool f) {
+	_renderer.setLogScale(f);
+
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SpectrogramWidget::logScale() const {
+	return _renderer.logScale();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::setTransferFunction(Math::Restitution::FFT::TransferFunction *tf) {
+	_renderer.setTransferFunction(tf);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::updateSpectrogram() {
+	if ( _renderer.isDirty() ) update();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::resizeEvent(QResizeEvent *e) {
+	QWidget::resizeEvent(e);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SpectrogramWidget::paintEvent(QPaintEvent *e) {
+	QPainter p(this);
+	p.setBrush(palette().color(QPalette::Window));
+	_renderer.render(p, rect());
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+}
+}

--- a/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramwidget.h
+++ b/src/gui-qt4/libs/seiscomp3/gui/core/spectrogramwidget.h
@@ -1,0 +1,124 @@
+/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#ifndef __SEISCOMP_GUI_CORE_SPECTROGRAMWIDGET_H__
+#define __SEISCOMP_GUI_CORE_SPECTROGRAMWIDGET_H__
+
+
+#include <QWidget>
+#include <seiscomp3/gui/core/spectrogramrenderer.h>
+
+
+namespace Seiscomp {
+namespace Gui {
+
+
+class SC_GUI_API SpectrogramWidget : public QWidget {
+	Q_OBJECT
+
+	// ----------------------------------------------------------------------
+	//  Public types
+	// ----------------------------------------------------------------------
+	public:
+		typedef IO::Spectralizer::Options SpectrumOptions;
+
+
+	// ----------------------------------------------------------------------
+	//  X'truction
+	// ----------------------------------------------------------------------
+	public:
+		SpectrogramWidget(QWidget *parent = 0, Qt::WindowFlags f = 0);
+
+
+	// ----------------------------------------------------------------------
+	//  Public Interface
+	// ----------------------------------------------------------------------
+	public:
+		//! Sets the spectrogram options and calls reset().
+		bool setSpectrumOptions(const SpectrumOptions &opts);
+
+		const SpectrumOptions &spectrumOptions() const;
+
+		//! Sets the scale of the raw stream data which is 1/gain
+		void setScale(double scale);
+
+		//! Sets the gradient range
+		void setGradientRange(double lowerBound, double upperBound);
+
+		double gradientLowerBound() const;
+		double gradientUpperBound() const;
+
+		//! Resets the spectrogram and deletes all data
+		void reset();
+
+		//! Feeds a record for processing. Records must be timely ordered
+		//! otherwise gaps are produced.
+		bool feed(const Record *rec);
+		bool feedSequence(const RecordSequence *seq);
+
+		//! Resets the view and feeds the sequence
+		void setRecords(const RecordSequence *seq);
+
+		void setAlignment(const Core::Time &align);
+		void setTimeRange(double tmin, double tmax);
+
+		//! Sets the current time window of the data
+		void setTimeWindow(const Core::TimeWindow &tw);
+
+		//! Sets the frequency range to be displayed. A value lower or equal to
+		//! zero refers to the global minimum or the global maximum
+		//! respectively.
+		void setFrequencyRange(OPT(double) fmin, OPT(double) fmax);
+
+		const OPT(double) &frequencyLowerBound() const;
+		const OPT(double) &frequencyUpperBound() const;
+
+		void setNormalizeAmplitudes(bool f);
+		bool normalizeAmplitudes() const;
+
+		void setLogScale(bool f);
+		bool logScale() const;
+
+		//! Sets the transfer function for deconvolution
+		void setTransferFunction(Math::Restitution::FFT::TransferFunction *tf);
+
+
+	// ----------------------------------------------------------------------
+	//  Public slots
+	// ----------------------------------------------------------------------
+	public slots:
+		void updateSpectrogram();
+
+
+	// ----------------------------------------------------------------------
+	//  Protected Qt Interface
+	// ----------------------------------------------------------------------
+	protected:
+		void resizeEvent(QResizeEvent *);
+		void paintEvent(QPaintEvent *);
+
+
+	// ----------------------------------------------------------------------
+	//  Private members
+	// ----------------------------------------------------------------------
+	private:
+		SpectrogramRenderer _renderer;
+};
+
+
+}
+}
+
+
+#endif

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.cpp
@@ -22,6 +22,7 @@
 #include <seiscomp3/gui/core/recordstreamthread.h>
 #include <seiscomp3/gui/core/timescale.h>
 #include <seiscomp3/gui/core/uncertainties.h>
+#include <seiscomp3/gui/core/spectrogramrenderer.h>
 #include <seiscomp3/client/inventory.h>
 #include <seiscomp3/client/configdb.h>
 #include <seiscomp3/datamodel/eventparameters.h>
@@ -108,6 +109,21 @@ class ZoomRecordWidget : public RecordWidget {
 			maxLower = maxUpper = 0;
 			currentIndex = -1;
 			crossHair = false;
+			showSpectrogram = false;
+			traces = NULL;
+
+			Gradient gradient;
+			gradient.setColorAt(0.0, QColor(255,   0, 255,   0));
+			gradient.setColorAt(0.2, QColor(  0,   0, 255, 255));
+			gradient.setColorAt(0.4, QColor(  0, 255, 255, 255));
+			gradient.setColorAt(0.6, QColor(  0, 255,   0, 255));
+			gradient.setColorAt(0.8, QColor(255, 255,   0, 255));
+			gradient.setColorAt(1.0, QColor(255,   0,   0, 255));
+
+			for ( int i = 0; i < 3; ++i ) {
+				spectrogram[i].setOptions(spectrogram[i].options());
+				spectrogram[i].setGradient(gradient);
+			}
 		}
 
 		void setUncertainties(const PickerView::Config::UncertaintyList &list) {
@@ -141,7 +157,131 @@ class ZoomRecordWidget : public RecordWidget {
 			update();
 		}
 
+		void setShowSpectrogram(bool enable) {
+			if ( showSpectrogram == enable ) return;
+
+			showSpectrogram = enable;
+
+			resetSpectrogram();
+			update();
+		}
+
+		void setLogSpectrogram(bool enable) {
+			for ( int i = 0; i < 3; ++i )
+				spectrogram[i].setLogScale(enable);
+			update();
+		}
+
+		void setMinSpectrogramRange(double v) {
+			for ( int i = 0; i < 3; ++i )
+				spectrogram[i].setGradientRange(v, spectrogram[i].gradientUpperBound());
+			update();
+		}
+
+		void setMaxSpectrogramRange(double v) {
+			for ( int i = 0; i < 3; ++i )
+				spectrogram[i].setGradientRange(spectrogram[i].gradientLowerBound(), v);
+			update();
+		}
+
+		void setSpectrogramTimeWindow(double tw) {
+			for ( int i = 0; i < 3; ++i ) {
+				IO::Spectralizer::Options opts = spectrogram[i].options();
+				opts.windowLength = tw;
+				spectrogram[i].setOptions(opts);
+			}
+
+			if ( showSpectrogram ) {
+				resetSpectrogram();
+				update();
+			}
+		}
+
+		void setTraces(ThreeComponentTrace::Component *t) {
+			traces = t;
+			resetSpectrogram();
+		}
+
+		void feedRaw(int slot, const Seiscomp::Record *rec) {
+			if ( showSpectrogram && (slot >= 0) && (slot < 3))
+				spectrogram[slot].feed(rec);
+		}
+
+	private:
+		void resetSpectrogram() {
+			if ( showSpectrogram ) {
+				qApp->setOverrideCursor(Qt::WaitCursor);
+				for ( int i = 0; i < 3; ++i ) {
+					const double *scale = recordScale(i);
+					// Scale is is nm and needs to be converted to m
+					if ( scale != NULL ) spectrogram[i].setScale(*scale * 1E-9);
+					spectrogram[i].setRecords(traces != NULL ? traces[i].raw : NULL);
+					spectrogram[i].renderSpectrogram();
+				}
+				qApp->restoreOverrideCursor();
+			}
+		}
+
+		void drawSpectrogram(QPainter &painter, int slot) {
+			QRect r = rect();
+			r.setHeight(streamHeight(slot));
+			r.moveTop(streamYPos(slot));
+			spectrogram[slot].setAlignment(alignment());
+			spectrogram[slot].setTimeRange(tmin(), tmax());
+			spectrogram[slot].render(painter, r, false, false);
+		}
+
+		void drawSpectrogramAxis(QPainter &painter, int slot) {
+			QRect r = rect();
+			r.setHeight(streamHeight(slot));
+			r.moveTop(streamYPos(slot));
+			spectrogram[slot].setAlignment(alignment());
+			spectrogram[slot].setTimeRange(tmin(), tmax());
+			spectrogram[slot].renderAxis(painter, r, false);
+		}
+
 	protected:
+		virtual void paintEvent(QPaintEvent *p) {
+			RecordWidget::paintEvent(p);
+
+			if ( showSpectrogram ) {
+				QPainter painter(this);
+				painter.setBrush(palette().color(QPalette::Window));
+
+				switch ( drawMode() ) {
+					case InRows:
+						for ( int i = 0; i < 3; ++i )
+							drawSpectrogramAxis(painter, i);
+						break;
+					case Single:
+						if ( (currentRecords() >= 0) && (currentRecords() < 3) )
+							drawSpectrogramAxis(painter, currentRecords());
+						break;
+					default:
+						break;
+				}
+			}
+		}
+
+		virtual void drawCustomBackground(QPainter &painter) {
+			if ( showSpectrogram ) {
+				painter.setBrush(palette().color(QPalette::Window));
+
+				switch ( drawMode() ) {
+					case InRows:
+						for ( int i = 0; i < 3; ++i )
+							drawSpectrogram(painter, i);
+						break;
+					case Single:
+						if ( (currentRecords() >= 0) && (currentRecords() < 3) )
+							drawSpectrogram(painter, currentRecords());
+						break;
+					default:
+						break;
+				}
+			}
+		}
+
 		virtual void drawActiveCursor(QPainter &painter, int x, int y) {
 			RecordWidget::drawActiveCursor(painter, x, y);
 
@@ -193,9 +333,12 @@ class ZoomRecordWidget : public RecordWidget {
 		PickerView::Config::UncertaintyList uncertainties;
 
 	private:
-		bool crossHair;
-		double maxLower, maxUpper;
-		int currentIndex;
+		bool                            crossHair;
+		double                          maxLower, maxUpper;
+		int                             currentIndex;
+		SpectrogramRenderer             spectrogram[3];
+		bool                            showSpectrogram;
+		ThreeComponentTrace::Component *traces;
 };
 
 
@@ -1341,22 +1484,13 @@ bool ThreeComponentTrace::transform(int comp, Seiscomp::Record *rec) {
 				comps[i] = rec;
 			}
 
-			// Create record sequences
+			// Trim record sizes
 			for ( int i = 0; i < 3; ++i ) {
 				FloatArray *data = static_cast<FloatArray*>(comps[i]->data());
 				if ( data->size() > minLen ) {
 					data->resize(minLen);
 					comps[i]->dataUpdated();
 				}
-
-				// Create ring buffer without limit if needed
-				if ( traces[i].transformed == NULL ) {
-					traces[i].transformed = new RingBuffer(0);
-					if ( widget ) widget->setRecords(i, traces[i].transformed, false);
-				}
-
-				traces[i].transformed->feed(comps[i].get());
-				if ( widget ) widget->fed(i, comps[i].get());
 			}
 
 			gotRecords = true;
@@ -1391,6 +1525,18 @@ bool ThreeComponentTrace::transform(int comp, Seiscomp::Record *rec) {
 			// And filter
 			for ( int i = 0; i < 3; ++i )
 				traces[i].filter.apply(comps[i].get());
+
+			// Create record sequences
+			for ( int i = 0; i < 3; ++i ) {
+				// Create ring buffer without limit if needed
+				if ( traces[i].transformed == NULL ) {
+					traces[i].transformed = new RingBuffer(0);
+					if ( widget ) widget->setRecords(i, traces[i].transformed, false);
+				}
+
+				traces[i].transformed->feed(comps[i].get());
+				if ( widget ) widget->fed(i, comps[i].get());
+			}
 
 			minStartTime = minEndTime;
 		}
@@ -1922,7 +2068,7 @@ void PickerView::init() {
 	addAction(_ui.actionShowZComponent);
 	addAction(_ui.actionShowNComponent);
 	addAction(_ui.actionShowEComponent);
-	
+
 	addAction(_ui.actionAlignOnOriginTime);
 	addAction(_ui.actionAlignOnPArrival);
 	addAction(_ui.actionAlignOnSArrival);
@@ -1958,6 +2104,8 @@ void PickerView::init() {
 	addAction(_ui.actionSwitchFullscreen);
 	addAction(_ui.actionAddStations);
 	addAction(_ui.actionSearchStation);
+
+	addAction(_ui.actionShowSpectrogram);
 
 	_lastFilterIndex = 0;
 
@@ -2001,6 +2149,8 @@ void PickerView::init() {
 	        this, SLOT(showTheoreticalArrivals(bool)));
 	connect(_ui.actionShowUnassociatedPicks, SIGNAL(triggered(bool)),
 	        this, SLOT(showUnassociatedPicks(bool)));
+	connect(_ui.actionShowSpectrogram, SIGNAL(triggered(bool)),
+	        this, SLOT(showSpectrogram(bool)));
 
 	_spinDistance = new QDoubleSpinBox;
 	_spinDistance->setValue(15);
@@ -2023,6 +2173,46 @@ void PickerView::init() {
 	        this, SLOT(loadNextStations()));
 	*/
 
+	QCheckBox *cb = new QCheckBox;
+	cb->setObjectName("spec.log");
+	cb->setText(tr("Logscale"));
+	cb->setChecked(false);
+	connect(cb, SIGNAL(toggled(bool)), this, SLOT(specLogToggled(bool)));
+	specLogToggled(cb->isChecked());
+
+	_ui.toolBarSpectrogram->addWidget(cb);
+
+	QDoubleSpinBox *spinLower = new QDoubleSpinBox;
+	spinLower->setMinimum(-100);
+	spinLower->setMaximum(100);
+	spinLower->setValue(-15);
+	connect(spinLower, SIGNAL(valueChanged(double)), this, SLOT(specMinValue(double)));
+	specMinValue(spinLower->value());
+
+	_ui.toolBarSpectrogram->addSeparator();
+	_ui.toolBarSpectrogram->addWidget(spinLower);
+
+	QDoubleSpinBox *spinUpper = new QDoubleSpinBox;
+	spinUpper->setMinimum(-100);
+	spinUpper->setMaximum(100);
+	spinUpper->setValue(-5);
+	connect(spinUpper, SIGNAL(valueChanged(double)), this, SLOT(specMaxValue(double)));
+	specMaxValue(spinUpper->value());
+
+	_ui.toolBarSpectrogram->addSeparator();
+	_ui.toolBarSpectrogram->addWidget(spinUpper);
+
+	QDoubleSpinBox *spinTW = new QDoubleSpinBox;
+	spinTW->setMinimum(0.1);
+	spinTW->setMaximum(600);
+	spinTW->setValue(5);
+	spinTW->setSuffix("s");
+	connect(spinTW, SIGNAL(valueChanged(double)), this, SLOT(specTimeWindow(double)));
+	specTimeWindow(spinTW->value());
+
+	_ui.toolBarSpectrogram->addSeparator();
+	_ui.toolBarSpectrogram->addWidget(spinTW);
+
 	// connect actions
 	connect(_ui.actionDefaultView, SIGNAL(triggered(bool)),
 	        this, SLOT(setDefaultDisplay()));
@@ -2039,7 +2229,7 @@ void PickerView::init() {
 	        this, SLOT(showNComponent()));
 	connect(_ui.actionShowEComponent, SIGNAL(triggered(bool)),
 	        this, SLOT(showEComponent()));
-	
+
 	connect(_ui.actionAlignOnOriginTime, SIGNAL(triggered(bool)),
 	        this, SLOT(alignOnOriginTime()));
 	connect(_ui.actionAlignOnPArrival, SIGNAL(triggered(bool)),
@@ -2907,11 +3097,11 @@ void PickerView::updatePhaseMarker(Seiscomp::Gui::RecordWidget* widget,
 				marker->setSlot(_currentSlot);
 				marker->setRotation(_currentRotationMode);
 				marker->setFilter(_currentFilterID);
-	
+
 				for ( int i = 0; i < widget->markerCount(); ++i ) {
 					PickerMarker *marker2 = (PickerMarker*)widget->marker(i);
 					if ( marker == marker2 ) continue;
-	
+
 					if ( marker2->text() == marker->text() && marker2->isArrival() ) {
 						// Set type back to pick. The phase code is updated
 						// automatically
@@ -3196,10 +3386,10 @@ void PickerView::loadNextStations() {
 				show = true;
 			else
 				show = item->value(ITEM_DISTANCE_INDEX) <= distance;
-	
+
 			if ( _ui.actionShowUsedStations->isChecked() )
 				show = show && isTraceUsed(item->widget());
-	
+
 			item->setVisible(show);
 		}
 	}
@@ -3370,15 +3560,15 @@ void PickerView::fetchComponent(char componentCode) {
 						     m->text().left(3) != "PcP" ) {
 							Core::Time start = m->time() - Core::TimeSpan(_config.preOffset);
 							Core::Time end = m->time() + Core::TimeSpan(_config.postOffset);
-		
+
 							if ( !tw.startTime().valid() || tw.startTime() > start )
 								tw.setStartTime(start);
-		
+
 							if ( !tw.endTime().valid() || tw.endTime() < end )
 								tw.setEndTime(end);
 						}
 					}
-	
+
 					it->timeWindow = tw;
 				}
 			}
@@ -3456,26 +3646,26 @@ void PickerView::loadNextStations(float distance) {
 			Network* n = inv->network(i);
 			for ( size_t j = 0; j < n->stationCount(); ++j ) {
 				Station* s = n->station(j);
-	
+
 				QString code = (n->code() + "." + s->code()).c_str();
-	
+
 				if ( _stations.contains(code) ) continue;
-	
+
 				try {
 					if ( s->end() <= _origin->time() )
 						continue;
 				}
 				catch ( Core::ValueException& ) {}
-	
+
 				double lat = s->latitude();
 				double lon = s->longitude();
 				double delta, az1, az2;
-	
+
 				Geo::delazi(_origin->latitude(), _origin->longitude(),
 				            lat, lon, &delta, &az1, &az2);
 
 				if ( delta > distance ) continue;
-	
+
 				// try to get the configured location and stream code
 				Stream *stream = findConfiguredStream(s, _origin->time());
 				if ( stream != NULL ) {
@@ -3505,7 +3695,7 @@ void PickerView::loadNextStations(float distance) {
 						               stream->code().c_str());
 					}
 				}
-	
+
 				if ( stream ) {
 					WaveformStreamID streamID(n->code(), s->code(), stream->sensorLocation()->code(), stream->code().substr(0,stream->code().size()-1) + '?', "");
 
@@ -3640,13 +3830,13 @@ bool PickerView::setOrigin(Seiscomp::DataModel::Origin* origin,
 	if ( origin->arrivalCount() > 0 ) {
 		for ( size_t i = 0; i < origin->arrivalCount(); ++i ) {
 			Arrival* arrival = origin->arrival(i);
-	
+
 			PickPtr pick = Pick::Cast(PublicObject::Find(arrival->pickID()));
 			if ( !pick ) {
 				//std::cout << "pick not found" << std::endl;
 				continue;
 			}
-	
+
 			WaveformStreamID streamID = adjustWaveformStreamID(pick->waveformID());
 			SensorLocation *loc = NULL;
 
@@ -3678,7 +3868,7 @@ bool PickerView::setOrigin(Seiscomp::DataModel::Origin* origin,
 				if ( isLinkedItem(item) )
 					unlinkItem(item);
 			}
-	
+
 			addArrival(item->widget(), arrival, i);
 		}
 	}
@@ -4251,7 +4441,7 @@ RecordViewItem* PickerView::addStream(const DataModel::SensorLocation *sloc,
 			streamID.networkCode(),
 			streamID.stationCode(),
 			_origin->time());
-	
+
 		if ( sta ) {
 			// Find the stream with given code priorities
 			Stream *stream = NULL;
@@ -4269,7 +4459,7 @@ RecordViewItem* PickerView::addStream(const DataModel::SensorLocation *sloc,
 
 				smStreamID.setChannelCode(stream->code());
 				smStreamID = adjustWaveformStreamID(smStreamID);
-	
+
 				hasStrongMotion = true;
 			}
 		}
@@ -5440,6 +5630,7 @@ void PickerView::itemSelected(RecordViewItem* item, RecordViewItem* lastItem) {
 		_currentRecord->clearRecords();
 		_currentRecord->setEnabled(false);
 		_currentRecord->setMarkerSourceWidget(NULL);
+		static_cast<ZoomRecordWidget*>(_currentRecord)->setTraces(NULL);
 		return;
 	}
 
@@ -5565,6 +5756,9 @@ void PickerView::itemSelected(RecordViewItem* item, RecordViewItem* lastItem) {
 	else
 		_ui.labelCode->setText("NO DATA");
 	*/
+
+	PickerRecordLabel *label = static_cast<PickerRecordLabel*>(item->label());
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setTraces(label->data.traces);
 
 	currentMarkerChanged(_currentRecord->currentMarker());
 
@@ -6127,7 +6321,7 @@ void PickerView::zoom(float factor) {
 
 	_currentRecord->setTimeScale(newScale);
 	_timeScale->setScale(newScale);
-	
+
 	if ( _checkVisibility ) ensureVisibility(tmin, tmax);
 	setTimeRange(tmin, tmax);
 }
@@ -6170,7 +6364,7 @@ void PickerView::scrollLeft() {
 		setCursorPos(cp);
 		return;
 	}
-	
+
 	float offset = -(float)width()/(8*_currentRecord->timeScale());
 	move(offset);
 }
@@ -6187,7 +6381,7 @@ if ( !_currentRecord->cursorText().isEmpty() ) {
 		setCursorPos(cp);
 		return;
 	}
-	
+
 	float offset = -1.0/_currentRecord->timeScale();
 	move(offset);
 }
@@ -6405,7 +6599,7 @@ void PickerView::fetchManualPicks(std::vector<RecordMarker*>* markers) const {
 						markers->push_back(marker);
 					SEISCOMP_DEBUG("   - reuse existing pick");
 				}
-					
+
 				continue;
 			}
 			*/
@@ -6759,14 +6953,6 @@ void PickerView::receivedRecord(Seiscomp::Record *rec) {
 	Seiscomp::RecordPtr tmp(rec);
 	if ( !rec->data() ) return;
 
-#ifndef WIN32
-	/*
-	std::cout << "[rec] " << rec->streamID() << " "
-	          << rec->startTime().iso() << " "
-	          << rec->endTime().iso() << std::endl;
-	*/
-#endif
-
 	std::string streamID = rec->streamID();
 	RecordItemMap::iterator it = _recordItemLabels.find(streamID);
 	if ( it == _recordItemLabels.end() )
@@ -6786,6 +6972,9 @@ void PickerView::receivedRecord(Seiscomp::Record *rec) {
 
 	bool firstRecord = label->data.traces[i].raw->empty();
 	if ( !label->data.traces[i].raw->feed(rec) ) return;
+
+	if ( label->recordViewItem() == _recordView->currentItem() )
+		static_cast<ZoomRecordWidget*>(_currentRecord)->feedRaw(i, rec);
 
 	// Check for out-of-order records
 	if ( (label->data.traces[i].filter || label->data.enableTransformation) &&
@@ -7345,6 +7534,42 @@ void PickerView::activateFilter(int index) {
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void PickerView::specLogToggled(bool e) {
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setLogSpectrogram(e);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void PickerView::specMinValue(double v) {
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setMinSpectrogramRange(v);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void PickerView::specMaxValue(double v) {
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setMaxSpectrogramRange(v);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void PickerView::specTimeWindow(double tw) {
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setSpectrogramTimeWindow(tw);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 void PickerView::limitFilterToZoomTrace(bool e) {
 	changeFilter(_comboFilter->currentIndex(), true);
 }
@@ -7406,6 +7631,15 @@ void PickerView::showUnassociatedPicks(bool v) {
 				m->setVisible(v);
 		}
 	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void PickerView::showSpectrogram(bool v) {
+	static_cast<ZoomRecordWidget*>(_currentRecord)->setShowSpectrogram(v);
 }
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
@@ -7626,7 +7860,7 @@ void PickerView::changeFilter(int index, bool force) {
 
 
 	bool filterApplied = false;
-	// Here one should 
+	// Here one should
 	if ( !_ui.actionLimitFilterToZoomTrace->isChecked() ) {
 		if ( _recordView->setFilterByName(filter) ) {
 			_currentRecord->setFilter(_recordView->filter());

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.h
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.h
@@ -355,10 +355,16 @@ class SC_GUI_API PickerView : public QMainWindow {
 		void updateRecordValue(Seiscomp::Core::Time);
 		void showTraceScaleToggled(bool);
 
+		void specLogToggled(bool);
+		void specMinValue(double);
+		void specMaxValue(double);
+		void specTimeWindow(double);
+
 		void limitFilterToZoomTrace(bool);
 
 		void showTheoreticalArrivals(bool);
 		void showUnassociatedPicks(bool);
+		void showSpectrogram(bool);
 
 		void toggleFilter();
 		void nextFilter();

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.ui
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/pickerview.ui
@@ -834,6 +834,17 @@
     <number>4</number>
    </attribute>
   </widget>
+  <widget class="QToolBar" name="toolBarSpectrogram" >
+   <property name="windowTitle" >
+    <string>Spectrogram</string>
+   </property>
+   <property name="orientation" >
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <attribute name="toolBarArea" >
+    <number>4</number>
+   </attribute>
+  </widget>
   <widget class="QToolBar" name="toolBarRelocate" >
    <property name="windowTitle" >
     <string>Apply</string>
@@ -861,6 +872,13 @@
      <height>29</height>
     </rect>
    </property>
+   <widget class="QMenu" name="menuPicking" >
+    <property name="title" >
+     <string>&amp;Picking</string>
+    </property>
+    <addaction name="actionRepickAutomatically" />
+    <addaction name="separator" />
+   </widget>
    <widget class="QMenu" name="menu_Filter" >
     <property name="title" >
      <string>&amp;Filter</string>
@@ -874,22 +892,6 @@
     </property>
     <addaction name="actionRelocate" />
     <addaction name="actionModifyOrigin" />
-   </widget>
-   <widget class="QMenu" name="menu_Navigation" >
-    <property name="title" >
-     <string>&amp;Navigation</string>
-    </property>
-    <addaction name="actionScrollLeft" />
-    <addaction name="actionScrollRight" />
-    <addaction name="actionScrollFineLeft" />
-    <addaction name="actionScrollFineRight" />
-   </widget>
-   <widget class="QMenu" name="menuPicking" >
-    <property name="title" >
-     <string>&amp;Picking</string>
-    </property>
-    <addaction name="actionRepickAutomatically" />
-    <addaction name="separator" />
    </widget>
    <widget class="QMenu" name="menuView" >
     <property name="title" >
@@ -953,10 +955,20 @@
     <addaction name="actionShowTraceValuesInNmS" />
     <addaction name="actionShowUnassociatedPicks" />
     <addaction name="actionShowTheoreticalArrivals" />
+    <addaction name="actionShowSpectrogram" />
     <addaction name="separator" />
     <addaction name="menu_Zoomtrace" />
     <addaction name="menuTraces" />
     <addaction name="menuComponents" />
+   </widget>
+   <widget class="QMenu" name="menu_Navigation" >
+    <property name="title" >
+     <string>&amp;Navigation</string>
+    </property>
+    <addaction name="actionScrollLeft" />
+    <addaction name="actionScrollRight" />
+    <addaction name="actionScrollFineLeft" />
+    <addaction name="actionScrollFineRight" />
    </widget>
    <addaction name="menuView" />
    <addaction name="menu_Navigation" />
@@ -1739,7 +1751,7 @@
     <string>Next filter</string>
    </property>
    <property name="shortcut" >
-    <string>g</string>
+    <string>G</string>
    </property>
   </action>
   <action name="actionPreviousFilter" >
@@ -1747,7 +1759,21 @@
     <string>Previous filter</string>
    </property>
    <property name="shortcut" >
-    <string>d</string>
+    <string>D</string>
+   </property>
+  </action>
+  <action name="actionShowSpectrogram" >
+   <property name="checkable" >
+    <bool>true</bool>
+   </property>
+   <property name="text" >
+    <string>Show spectrogram</string>
+   </property>
+   <property name="statusTip" >
+    <string/>
+   </property>
+   <property name="shortcut" >
+    <string>shift+s</string>
    </property>
   </action>
  </widget>

--- a/src/trunk/libs/seiscomp3/core/version.h
+++ b/src/trunk/libs/seiscomp3/core/version.h
@@ -23,12 +23,12 @@ namespace Seiscomp {
 namespace Core {
 
 
-/* #if (SC_API_VERSION >= SC_API_VERSION_CHECK(1, 15, 0)) */
+/* #if (SC_API_VERSION >= SC_API_VERSION_CHECK(1, 16, 0)) */
 #define SC_API_VERSION_CHECK(major, minor, patch) ((major<<16)|(minor<<8)|(patch))
 
 
 /* SC_API_VERSION is (major << 16) + (minor << 10) + patch. */
-#define SC_API_VERSION 0x010F00
+#define SC_API_VERSION 0x011000
 
 #define SC_API_VERSION_MAJOR(v) (v >> 16)
 #define SC_API_VERSION_MINOR(v) ((v >> 8) & 0xff)
@@ -38,6 +38,14 @@ namespace Core {
 /******************************************************************************
  API Changelog
  ******************************************************************************
+ "1.16.0"  0x011000
+   - Added Seiscomp::IO::Spectralizer
+   - Added Seiscomp::Gui::LUT
+   - Added Seiscomp::Gui::StaticLUT
+   - Added Seiscomp::Gui::StaticColorLUT
+   - Added Seiscomp::Gui::SpectrogramRenderer
+   - Added Seiscomp::Gui::SpectrogramWidget
+
  "1.15.0"  0x010F00
    - Added Seiscomp::Math::Geo::delazi_wgs84
 

--- a/src/trunk/libs/seiscomp3/io/recordfilter/CMakeLists.txt
+++ b/src/trunk/libs/seiscomp3/io/recordfilter/CMakeLists.txt
@@ -2,12 +2,14 @@ SET(RECORDFILTER_SOURCES
 	iirfilter.cpp
 	resample.cpp
 	demux.cpp
+	spectralizer.cpp
 )
 
 SET(RECORDFILTER_HEADERS
 	iirfilter.h
 	resample.h
 	demux.h
+	spectralizer.h
 )
 
 SC_SETUP_LIB_SUBDIR(RECORDFILTER)

--- a/src/trunk/libs/seiscomp3/io/recordfilter/spectralizer.cpp
+++ b/src/trunk/libs/seiscomp3/io/recordfilter/spectralizer.cpp
@@ -1,0 +1,439 @@
+﻿/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#define SEISCOMP_COMPONENT SPEC
+
+#include <seiscomp3/logging/log.h>
+#include <seiscomp3/core/strings.h>
+#include <seiscomp3/math/fft.h>
+
+#include "spectralizer.h"
+
+
+using namespace std;
+using namespace Seiscomp;
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+namespace {
+
+
+void copy(DoubleArray &dst, int iofs, vector<double> &src, int front) {
+	int chunkSize = src.size()-front;
+	memcpy(dst.typedData()+iofs, src.data()+front, chunkSize*sizeof(double));
+	memcpy(dst.typedData()+iofs+chunkSize, src.data(), front*sizeof(double));
+}
+
+
+struct Mag {
+	static double score(const Math::Complex &c) {
+		return abs(c);
+	}
+
+	static double score(const double &c) {
+		return fabs(c);
+	}
+};
+
+
+template <typename S, typename T>
+void reduce(TypedArray<T> &spec, int n) {
+	int s = spec.size();
+
+	if ( n > s ) return;
+
+	int from = 0;
+	typename TypedArray<T>::Type m;
+
+	for ( int i = 0; i < n; ++i ) {
+		int to = (i+1)*s/n;
+
+		m = spec[from];
+		for ( int j = from+1; j < to; ++j ) {
+			if ( S::score(m) < S::score(spec[j]) )
+				m = spec[j];
+		}
+		spec[i] = m;
+
+		from = to;
+	}
+
+	spec.resize(n);
+}
+
+
+template <typename T>
+void demean(int n, T *inout) {
+	T sum = 0;
+	for ( int i = 0; i < n; ++i )
+		sum += inout[i];
+
+	T mean = sum/n;
+	for ( int i = 0; i < n; ++i )
+		inout[i] -= mean;
+}
+
+
+template <typename T>
+void detrend(int n, T *data) {
+	if ( n <= 1 ) return;
+
+	T a,b;
+
+	T xm = T(n-1)*(T)0.5;
+	T ym = 0;
+
+	for ( int i = 0; i < n; ++i )
+		ym += data[i];
+
+	ym /= (T)n;
+
+	T covar = 0, varx = 0;
+
+	for ( int i = 0; i < n; ++i ) {
+		T x = (T)i-xm;
+		covar += x*(data[i]-ym);
+		varx += x*x;
+	}
+
+	a = covar / varx;
+	b = ym - a*xm;
+
+	for ( int i = 0; i < n; ++i )
+		data[i] = data[i] - (b + a*(T)i);
+}
+
+
+template <typename T>
+void hann(int n, T *inout, double width) {
+	if ( width > 0.5 ) width = 0.5;
+	else if ( width < 0 ) width = 0;
+
+	double n2 = n*width;
+	if ( n2 > n ) n2 = n;
+	int in2 = (int)n2;
+	int w = in2*2;
+
+	for ( int i = 0; i < in2; ++i ) {
+		inout[i] *= 0.5+0.5*cos(2*M_PI*(i-n2)/w);
+		inout[n-i-1] *= 0.5+0.5*cos(2*M_PI*(i-n2)/w);
+	}
+}
+
+
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+namespace Seiscomp {
+namespace IO {
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Spectralizer::Options::Options() {
+	windowLength = 20;
+	windowOverlap = 0.5;
+	specSamples = -1;
+	taperWidth = 0.05;
+	noalign = false;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Spectralizer::Spectralizer() {
+	// Default window length is 20s
+	_windowLength = 20;
+	// Default time step is 10s (50% overlap)
+	_timeStep = 10;
+	_specSamples = -1;
+	_noalign = false;
+	_filter = NULL;
+	// Default taper width is 5%
+	_taperWidth = 0.05;
+	_buffer = NULL;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Spectralizer::~Spectralizer() {
+	cleanup();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool Spectralizer::setOptions(const Options &opts) {
+	_windowLength = opts.windowLength;
+	_taperWidth = opts.taperWidth;
+	if ( _taperWidth < 0 ) _taperWidth = 0;
+	else if ( _taperWidth > 0.5 ) _taperWidth = 0.5;
+
+	SEISCOMP_DEBUG("[spec] windowLength = %fs", _windowLength);
+	SEISCOMP_DEBUG("[spec] windowOverlap = %f%%", opts.windowOverlap*100);
+	SEISCOMP_DEBUG("[spec] samples = %d", opts.specSamples);
+	SEISCOMP_DEBUG("[spec] filter = %s", opts.filter.c_str());
+	SEISCOMP_DEBUG("[spec] taperWidth = %f", _taperWidth);
+
+	if ( opts.windowOverlap < 1 )
+		_timeStep = _windowLength * (1-opts.windowOverlap);
+	else
+		return false;
+
+	_specSamples = opts.specSamples;
+	_noalign = opts.noalign;
+
+	if ( !opts.filter.empty() ) {
+		_filter = Math::Filtering::InPlaceFilter<double>::Create(opts.filter);
+		if ( !_filter ) return false;
+	}
+
+	return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void Spectralizer::cleanup() {
+	if ( _buffer != NULL ) {
+		delete _buffer;
+		_buffer = NULL;
+	}
+
+	while ( !_nextSpectra.empty() ) {
+		delete _nextSpectra.front();
+		_nextSpectra.pop_front();
+	}
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void Spectralizer::init(const Record *rec) {
+	_buffer->sampleRate = rec->samplingFrequency();
+	_buffer->dt = 1.0/_buffer->sampleRate;
+	_buffer->buffer.resize(_buffer->sampleRate*_windowLength);
+	_buffer->tmpOffset = 0;
+	_buffer->tmp.resize(_buffer->buffer.size() + _buffer->tmpOffset*2);
+	_buffer->tmp.fill(0.0);
+	_buffer->reset(_filter);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool Spectralizer::push(const Record *rec) {
+	if ( _buffer == NULL ) {
+		_buffer = new SpecBuffer;
+		init(rec);
+	}
+	else {
+		// Sample rate changed? Check new settings and reset
+		// the spec calculation.
+		if ( _buffer->sampleRate != rec->samplingFrequency() ) {
+			_buffer->reset(_filter);
+			init(rec);
+		}
+	}
+
+	fft(rec);
+
+	return !_nextSpectra.empty();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Spectrum *Spectralizer::pop() {
+	if ( _nextSpectra.empty() ) return NULL;
+
+	Spectrum *front = _nextSpectra.front();
+	_nextSpectra.pop_front();
+	return front;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+Record *Spectralizer::fft(const Record *rec) {
+	Core::Time endTime;
+	try {
+		endTime = rec->endTime();
+	}
+	catch ( ... ) {
+		SEISCOMP_WARNING("[dec] %s: invalid end time -> ignoring",
+		                 rec->streamID().c_str());
+		return NULL;
+	}
+
+	if ( _buffer->lastEndTime.valid() ) {
+		double diff = rec->startTime() - _buffer->lastEndTime;
+		if ( fabs(diff) > _buffer->dt*0.5 ) {
+			SEISCOMP_DEBUG("[spec] %s: gap/overlap of %f secs -> reset processing",
+			               rec->streamID().c_str(), diff);
+			_buffer->reset(_filter);
+		}
+	}
+
+	_buffer->lastEndTime = endTime;
+
+	ArrayPtr tmp_ar;
+	const DoubleArray *ar = DoubleArray::ConstCast(rec->data());
+	if ( ar == NULL ) {
+		tmp_ar = rec->data()->copy(Array::DOUBLE);
+		ar = DoubleArray::ConstCast(tmp_ar);
+		if ( ar == NULL ) {
+			SEISCOMP_ERROR("[spec] internal error: doubles expected");
+			return NULL;
+		}
+	}
+
+	size_t data_len = (size_t)ar->size();
+	const double *data = ar->typedData();
+	double *buffer = &_buffer->buffer[0];
+
+	if ( _buffer->filter )
+		_buffer->filter->apply(data_len, (double*)data);
+
+	if ( _buffer->missingSamples > 0 ) {
+		size_t toCopy = std::min(_buffer->missingSamples, data_len);
+		memcpy(buffer + _buffer->buffer.size() - _buffer->missingSamples,
+		       data, toCopy*sizeof(double));
+		data += toCopy;
+		data_len -= toCopy;
+		_buffer->missingSamples -= toCopy;
+
+		if ( !_buffer->startTime.valid() ) {
+			_buffer->startTime = rec->startTime();
+
+			// align to timestep if not requested otherwise
+			if ( !_noalign ) {
+				double mod = fmod((double)_buffer->startTime, _timeStep);
+				double skip = _timeStep - mod;
+				_buffer->samplesToSkip = int(skip*_buffer->sampleRate+0.5);
+
+				Core::Time nextStep(floor(double(_buffer->startTime)/_timeStep+(_buffer->samplesToSkip > 0?1:0))*_timeStep+5E-7);
+				_buffer->startTime = nextStep - Core::TimeSpan(_buffer->samplesToSkip*_buffer->dt+5E-7);
+			}
+		}
+
+		// Still samples missing and no more data available, return
+		if ( _buffer->missingSamples > 0 ) return NULL;
+	}
+
+	do {
+		if ( _buffer->samplesToSkip == 0 ) {
+			ComplexDoubleArrayPtr spec;
+			Core::Time startTime;
+
+			// Calculate spectrum from ringbuffer
+			startTime = _buffer->startTime;
+
+			// Copy data
+			copy(_buffer->tmp, _buffer->tmpOffset, _buffer->buffer, _buffer->front);
+
+			size_t sampleCount = _buffer->buffer.size();
+
+			// Demean data excluding the padding window
+			demean(_buffer->tmp.size()-_buffer->tmpOffset*2, _buffer->tmp.typedData()+_buffer->tmpOffset);
+			// Detrend data excluding the padding window
+			detrend(_buffer->tmp.size()-_buffer->tmpOffset*2, _buffer->tmp.typedData()+_buffer->tmpOffset);
+			// Apply Von-Hann window
+			hann(_buffer->tmp.size()-_buffer->tmpOffset*2, _buffer->tmp.typedData()+_buffer->tmpOffset, _taperWidth);
+
+			spec = new ComplexDoubleArray;
+			Math::fft(spec->impl(), _buffer->tmp.size(), _buffer->tmp.typedData());
+
+			if ( _specSamples > 0 )
+				reduce<Mag>(*spec, _specSamples);
+
+			if ( spec ) {
+				Spectrum *spectrum;
+				spectrum = new Spectrum(startTime, startTime + Core::TimeSpan(sampleCount*_buffer->dt),
+				                        _timeStep, _buffer->sampleRate*0.5,
+				                        (int)sampleCount/2);
+				spectrum->setData(spec.get());
+				_nextSpectra.push_back(spectrum);
+			}
+
+			// Still need to wait until N samples have been fed.
+			_buffer->samplesToSkip = _buffer->sampleRate * _timeStep + 0.5;
+		}
+
+		size_t num_samples = std::min(_buffer->samplesToSkip, data_len);
+
+		size_t chunk_size = std::min(num_samples, _buffer->buffer.size()-_buffer->front);
+		memcpy(buffer + _buffer->front, data, chunk_size*sizeof(double));
+
+		data += chunk_size;
+
+		// Split chunks
+		if ( chunk_size < num_samples ) {
+			chunk_size = num_samples - chunk_size;
+
+			memcpy(buffer, data, chunk_size*sizeof(double));
+
+			_buffer->front = chunk_size;
+
+			data += chunk_size;
+		}
+		else {
+			_buffer->front += chunk_size;
+			if ( _buffer->front >= _buffer->buffer.size() )
+				_buffer->front -= _buffer->buffer.size();
+		}
+
+		_buffer->startTime += Core::TimeSpan(_buffer->dt*num_samples+5E-7);
+		_buffer->samplesToSkip -= num_samples;
+
+		data_len -= num_samples;
+	}
+	while ( data_len > 0 );
+
+	return NULL;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+
+
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+}
+}

--- a/src/trunk/libs/seiscomp3/io/recordfilter/spectralizer.h
+++ b/src/trunk/libs/seiscomp3/io/recordfilter/spectralizer.h
@@ -1,0 +1,207 @@
+﻿/***************************************************************************
+ *   Copyright (C) by gempa GmbH                                           *
+ *   Author: Jan Becker, gempa GmbH                                        *
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+
+#ifndef __SEISCOMP_IO_RECORDFILTER_SPECTRALIZER__
+#define __SEISCOMP_IO_RECORDFILTER_SPECTRALIZER__
+
+
+#include <map>
+#include <deque>
+
+#include <seiscomp3/math/filter.h>
+#include <seiscomp3/core/typedarray.h>
+#include <seiscomp3/core/genericrecord.h>
+
+
+namespace Seiscomp {
+namespace IO {
+
+
+DEFINE_SMARTPOINTER(Spectrum);
+class SC_SYSTEM_CORE_API Spectrum : public Core::BaseObject {
+	public:
+		Spectrum(const Core::Time &stime,
+		         const Core::Time &etime,
+		         const Core::TimeSpan &dt,
+		         double freq, int sampleCount)
+		: _startTime(stime), _endTime(etime), _dt(dt), _sampleCount(sampleCount)
+		, _frequency(freq) {}
+
+		void setData(ComplexDoubleArray *data) {
+			_data = data;
+		}
+
+		bool isValid() const { return _data && _data->size() > 0; }
+
+		ComplexDoubleArray *data() { return _data.get(); }
+
+		const Core::Time &startTime() const { return _startTime; }
+		const Core::Time &endTime() const { return _endTime; }
+		const Core::TimeSpan &dt() const { return _dt; }
+
+		Core::TimeSpan length() const { return _endTime - _startTime; }
+		Core::Time center() const { return Core::Time(double(_startTime + _endTime)*0.5); }
+
+		double minimumFrequency() const { return 0; }
+		double maximumFrequency() const { return _frequency; }
+
+
+	private:
+		Core::Time            _startTime;
+		Core::Time            _endTime;
+		Core::TimeSpan        _dt;
+		int                   _sampleCount;
+		double                _frequency;
+		ComplexDoubleArrayPtr _data;
+};
+
+
+
+DEFINE_SMARTPOINTER(Spectralizer);
+class SC_SYSTEM_CORE_API Spectralizer : public Core::BaseObject {
+	// ----------------------------------------------------------------------
+	//  Public types
+	// ----------------------------------------------------------------------
+	public:
+		/**
+		 * @brief The Options struct holds the parameters used to
+		 * compute the spectrum.
+		 */
+		struct Options {
+			Options();
+
+			//! The window length in seconds used to compute the spectrum.
+			double      windowLength;
+			//! The window overlap for subsequent spectra. This value is
+			//! defined as a fraction of windowLength and must be in [0,1).
+			//! The effective time step is windowLength*windowOverlap.
+			double      windowOverlap;
+			//! The output spectrum samples. A value of -1 returns the full
+			//! spectrum whereas values > 0 reduce the spectrum to the given
+			//! number of samples using the maximum value of each bin with
+			//! respect to magnitude of each spectrum sample.
+			int         specSamples;
+			//! An optional filter applied in advance to compute a spectrum.
+			std::string filter;
+			//! Disables aligning the processed time window with the given
+			//! time step.
+			bool        noalign;
+			//! The taper width applied to either side of the processed time
+			//! window given as fraction of windowLength, e.g. 0.05 for 5%.
+			double      taperWidth;
+		};
+
+
+	// ----------------------------------------------------------------------
+	//  X'truction
+	// ----------------------------------------------------------------------
+	public:
+		Spectralizer();
+		virtual ~Spectralizer();
+
+
+	// ----------------------------------------------------------------------
+	//  Public Interface
+	// ----------------------------------------------------------------------
+	public:
+		bool setOptions(const Options &opts);
+
+		//! Push an record and compute spectra. Returns true if a records
+		//! can be popped. The record id (net,sta,loc,cha) is not checked
+		//! against the last record pushed. This filtering is left to
+		//! the caller.
+		bool push(const Record *rec);
+
+		//! Pops an spectrum if available. Returns NULL if more data are
+		//! required.
+		Spectrum *pop();
+
+		//! Returns whether records are available
+		bool canPop() const { return !_nextSpectra.empty(); }
+
+		//! Clean up all associated resources
+		void cleanup();
+
+
+	// ----------------------------------------------------------------------
+	//  Implementation
+	// ----------------------------------------------------------------------
+	private:
+		typedef Core::SmartPointer< Math::Filtering::InPlaceFilter<double> >::Impl FilterPtr;
+		struct SpecBuffer {
+			SpecBuffer() {}
+			~SpecBuffer() {}
+
+			FilterPtr filter;
+
+			// Fixed source sample rate derived from the first record
+			// received.
+			double sampleRate;
+			double dt;
+
+			// The ring buffer that holds the last samples for fft.
+			std::vector<double> buffer;
+			DoubleArray tmp;
+			int tmpOffset;
+
+			size_t samplesToSkip;
+
+			// The number of samples still missing in the buffer before
+			// fft can be done
+			size_t missingSamples;
+
+			// The front index of the ring buffer
+			size_t front;
+
+			// Time of front of ring buffer
+			Core::Time startTime;
+
+			// End time of last record
+			Core::Time lastEndTime;
+
+			void reset(FilterPtr refFilter) {
+				missingSamples = buffer.size();
+				front = 0;
+				samplesToSkip = 0;
+				startTime = Core::Time();
+				lastEndTime = Core::Time();
+
+				if ( refFilter ) {
+					filter = refFilter->clone();
+					filter->setSamplingFrequency(sampleRate);
+				}
+				else
+					filter = NULL;
+			}
+		};
+
+		void init(const Record *rec);
+		Record *fft(const Record *rec);
+
+		double                        _windowLength;
+		double                        _timeStep;
+		bool                          _noalign;
+		int                           _specSamples;
+		double                        _taperWidth;
+		FilterPtr                     _filter;
+		SpecBuffer                   *_buffer;
+		std::deque<Spectrum*>         _nextSpectra;
+};
+
+
+}
+}
+
+
+#endif


### PR DESCRIPTION
This implements a spectrogram layer in the manual picker window. The spectrogram view can be toggled with ctrl+s and is by default off. A new toolbar has been added as well to configure the spectrogram, in particular spectra window length and window overlap.
Ping @marcopovitch.