### PR TITLE
[scevent] Added --ep to process offline datasets

### DIFF
--- a/src/trunk/apps/processing/scevent/eventtool.h
+++ b/src/trunk/apps/processing/scevent/eventtool.h
@@ -224,6 +224,7 @@ class EventTool : public Application {
 		Util::StopWatch               _timer;
 		std::string                   _originID;
 		std::string                   _eventID;
+		std::string                   _epFile;
 
 		Config                        _config;
 		EventProcessors               _processors;

--- a/src/trunk/apps/processing/scevent/util.cpp
+++ b/src/trunk/apps/processing/scevent/util.cpp
@@ -201,7 +201,7 @@ string allocateEventID(DatabaseArchive *ar, const Origin *origin,
 
 	string text;
 	string eventID = generateEventID(year, x, prefix, pattern, text, &width);
-	ObjectPtr o = ar?ar->getObject(Event::TypeInfo(), eventID):NULL;
+	ObjectPtr o = ar?ar->getObject(Event::TypeInfo(), eventID):Event::Find(eventID);
 	bool blocked = (blackList != NULL) && (blackList->find(text) != blackList->end());
 
 	if ( !o && !blocked )
@@ -212,7 +212,7 @@ string allocateEventID(DatabaseArchive *ar, const Origin *origin,
 	for ( int i = 1; i < 5; ++i ) {
 		eventID = generateEventID(year, x+i*width, prefix, pattern, text);
 		blocked = (blackList != NULL) && (blackList->find(text) != blackList->end());
-		o = ar?ar->getObject(Event::TypeInfo(), eventID):NULL;
+		o = ar?ar->getObject(Event::TypeInfo(), eventID):Event::Find(eventID);
 		if ( !o && !blocked )
 			return eventID;
 		if ( blocked ) SEISCOMP_WARNING("Blocked ID: %s (rejected %s)", eventID.c_str(), text.c_str());
@@ -221,7 +221,7 @@ string allocateEventID(DatabaseArchive *ar, const Origin *origin,
 	for ( int i = 1; i < 5; ++i ) {
 		eventID = generateEventID(year, x-i*width, prefix, pattern, text);
 		blocked = (blackList != NULL) && (blackList->find(text) != blackList->end());
-		o = ar?ar->getObject(Event::TypeInfo(), eventID):NULL;
+		o = ar?ar->getObject(Event::TypeInfo(), eventID):Event::Find(eventID);
 		if ( !o && !blocked )
 			return eventID;
 		if ( blocked ) SEISCOMP_WARNING("Blocked ID: %s (rejected %s)", eventID.c_str(), text.c_str());


### PR DESCRIPTION
To be able to run full offline processing through pipes, scevent needs the ```--ep``` functionality as well which is the objective of this PR.

Example:
```
scevent --ep origins_and_picks.xml > events.xml
```

scevent will read all origin from the XML file and either try to associate them with existing events or create new events. The data model is being updated and written to stdout in XML format again.