### PR TITLE
[hypo71] Fixed crash when build as Release

### DIFF
--- a/src/ipgp/plugins/locator/hypo71/hypo71.cpp
+++ b/src/ipgp/plugins/locator/hypo71/hypo71.cpp
@@ -696,7 +696,7 @@ const int Hypo71::getH71Weight(const PickList& pickList,
                                const string& phaseCode,
                                const double& max) {
 
-	int weight = 0;
+	int weight = 4;
 	double upper = 0, lower = 0;
 	string pickID;
 


### PR DESCRIPTION
The hypo71 locator plugin crashes when built with enabled compiler optimizations. I fixed the crash as well as some uninitialized values. @ovsm-dev, can you please check if the initializations are correct? I added comments to the commit.