### PR TITLE
Corrected filtering of MOD_ID and INST_ID

### DIFF
--- a/src/ipgp/apps/ew2sc3/ew2sc3.cpp
+++ b/src/ipgp/apps/ew2sc3/ew2sc3.cpp
@@ -572,12 +572,12 @@ int EW2SC3::ew_read() {
 
 						// Accept messages which institudeID matches 0 (earthworm WILDCARD),
 						// 255 (earthworm UNKNOWN) or specified ID only.
-						if ( (atoi(msg_inst) == _instID) || (atoi(msg_inst) == INST_WILDCARD)
+						if ( (atoi(msg_inst) == _instID) || (_instID == INST_WILDCARD)
 						        || (atoi(msg_inst) == INST_UNKNOWN) ) {
 
 							// Accept messages which moduleID is 0 (earthworm WILDCARD)
 							// or specified ID only.
-							if ( (atoi(msg_mod) == _modID) || (atoi(msg_mod) == MOD_WILDCARD) ) {
+							if ( (atoi(msg_mod) == _modID) || (_modID == MOD_WILDCARD) ) {
 
 								SEISCOMP_LOG(_infoChannel, "Incoming origin from Earthworm "
 									"[msgID: %d | instID: %d | modID: %d]",


### PR DESCRIPTION
When the filter criteria for module_ID and/or institute_ID is set to WILDCARD in the config file, we want all messages to be accepted, whatever their module_ID and/or institude_ID is.
This was not the case in the previous test and have been corrected.

Jean-Marie Saurel