### PR TITLE
[fdsnws] fixed missing lines in text format of station and event service

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/event.py
+++ b/src/trunk/apps/fdsnws/fdsnws/event.py
@@ -423,7 +423,7 @@ class FDSNEvent(resource.Resource):
 		       "Contributor|ContributorID|MagType|Magnitude|MagAuthor|" \
 		       "EventLocationName\n"
 		df = "%FT%T.%f"
-		req.write(line)
+		utils.writeTS(req, line)
 		byteCount = len(line)
 
 		# add related information
@@ -485,7 +485,7 @@ class FDSNEvent(resource.Resource):
 			       eID, o.time().value().toString(df), o.latitude().value(),
 			       o.longitude().value(), depth, author, contrib, eID,
 			       mType, mVal, mAuthor, region)
-			req.write(line)
+			utils.writeTS(req, line)
 			lineCount +=1
 			byteCount += len(line)
 
@@ -540,7 +540,7 @@ class FDSNEvent(resource.Resource):
 			msg = "no matching events found"
 			data = HTTP.renderErrorPage(req, http.NO_CONTENT, msg, ro)
 			if data:
-				req.write(data)
+				utils.writeTS(req, data)
 			return True
 
 		Logging.debug("events found: %i" % ep.eventCount())

--- a/src/trunk/apps/fdsnws/fdsnws/station.py
+++ b/src/trunk/apps/fdsnws/fdsnws/station.py
@@ -357,7 +357,7 @@ class FDSNStation(resource.Resource):
 			msg = "no matching inventory found"
 			data = HTTP.renderErrorPage(req, http.NO_CONTENT, msg, ro)
 			if data:
-				req.write(data)
+				utils.writeTS(req, data)
 			return True
 
 		# Copy references (dataloggers, responses, sensors)
@@ -391,20 +391,17 @@ class FDSNStation(resource.Resource):
 	def _processRequestText(self, req, ro):
 		if req._disconnected: return False
 
-		lineCount, byteCount = 0, 0
+		lineCount = 0
 		skipRestricted = not self._allowRestricted or \
 		                 (ro.restricted is not None and not ro.restricted)
 
-		headerNet = "#Network|Description|StartTime|EndTime|TotalStations\n"
-		headerSta = "#Network|Station|Latitude|Longitude|Elevation|" \
-		            "SiteName|StartTime|EndTime\n"
-		headerCha = "#Network|Station|Location|Channel|Latitude|Longitude|" \
-		            "Elevation|Depth|Azimuth|Dip|SensorDescription|Scale|" \
-		            "ScaleFreq|ScaleUnits|SampleRate|StartTime|EndTime\n"
 		df = "%FT%T"
+		data = ""
 
 		# level = network
 		if not ro.includeSta:
+			data = "#Network|Description|StartTime|EndTime|TotalStations\n"
+
 			# iterate over inventory networks
 			for net in ro.networkIter(self._inv, True):
 				if req._disconnected: return False
@@ -418,21 +415,19 @@ class FDSNStation(resource.Resource):
 						break
 				if not stationFound: continue
 
-				if lineCount == 0:
-					req.write(headerNet)
-					byteCount = len(headerNet)
 				try: end = net.end().toString(df)
 				except ValueException: end = ''
 
-				line = "%s|%s|%s|%s|%i\n" % (net.code(),
-				       net.description(), net.start().toString(df), end,
-				       net.stationCount())
-				req.write(line)
+				data += "%s|%s|%s|%s|%i\n" % (net.code(),
+				        net.description(), net.start().toString(df), end,
+				        net.stationCount())
 				lineCount += 1
-				byteCount += len(line)
 
 		# level = station
 		elif not ro.includeCha:
+			data = "#Network|Station|Latitude|Longitude|Elevation|" \
+			       "SiteName|StartTime|EndTime\n"
+
 			# iterate over inventory networks
 			for net in ro.networkIter(self._inv, False):
 				if req._disconnected: return False
@@ -441,9 +436,6 @@ class FDSNStation(resource.Resource):
 				for sta in ro.stationIter(net, True):
 					if not self._matchStation(sta, ro): continue
 
-					if lineCount == 0:
-						req.write(headerSta)
-						byteCount = len(headerSta)
 					try: lat = str(sta.latitude())
 					except ValueException: lat = ''
 					try: lon = str(sta.longitude())
@@ -455,16 +447,17 @@ class FDSNStation(resource.Resource):
 					try: end = sta.end().toString(df)
 					except ValueException: end = ''
 
-					line = "%s|%s|%s|%s|%s|%s|%s|%s\n" % (
-					       net.code(), sta.code(), lat, lon, elev, desc,
-					       sta.start().toString(df), end)
-					req.write(line)
+					data += "%s|%s|%s|%s|%s|%s|%s|%s\n" % (
+					        net.code(), sta.code(), lat, lon, elev, desc,
+					        sta.start().toString(df), end)
 					lineCount += 1
-					byteCount += len(line)
 
 		# level = channel|response
 		else:
-			lineFmt = "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
+			data = "#Network|Station|Location|Channel|Latitude|Longitude|" \
+			       "Elevation|Depth|Azimuth|Dip|SensorDescription|Scale|" \
+			       "ScaleFreq|ScaleUnits|SampleRate|StartTime|EndTime\n"
+
 			# iterate over inventory networks
 			for net in ro.networkIter(self._inv, False):
 				if req._disconnected: return False
@@ -475,9 +468,6 @@ class FDSNStation(resource.Resource):
 						for stream in ro.streamIter(loc, True):
 							if skipRestricted and utils.isRestricted(stream): continue
 
-							if lineCount == 0:
-								req.write(headerCha)
-								byteCount = len(headerSta)
 							try: lat = str(loc.latitude())
 							except ValueException: lat = ''
 							try: lon = str(loc.longitude())
@@ -512,27 +502,26 @@ class FDSNStation(resource.Resource):
 							try: end = stream.end().toString(df)
 							except ValueException: end = ''
 
-							line = lineFmt % (net.code(), sta.code(),
-							       loc.code(), stream.code(), lat, lon,
-							       elev, depth, azi, dip, desc, scale,
-							       scaleFreq, scaleUnit, sr,
-							       stream.start().toString(df), end)
-							req.write(line)
+							data += "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|" \
+							        "%s|%s|%s|%s\n" % (net.code(), sta.code(),
+							        loc.code(), stream.code(), lat, lon,
+							        elev, depth, azi, dip, desc, scale,
+							        scaleFreq, scaleUnit, sr,
+							        stream.start().toString(df), end)
 							lineCount += 1
-							byteCount += len(line)
 
 		# Return 204 if no matching inventory was found
 		if lineCount == 0:
 			msg = "no matching inventory found"
 			data = HTTP.renderErrorPage(req, http.NO_CONTENT, msg, ro)
 			if data:
-				req.write(data)
+				utils.writeTS(req, data)
 			return False
 
-
+		utils.writeTS(req, data)
 		Logging.notice("%s: returned %i lines (total bytes: %i)" % (
-		               ro.service, lineCount, byteCount))
-		utils.accessLog(req, ro, http.OK, byteCount, None)
+		               ro.service, lineCount, len(data)))
+		utils.accessLog(req, ro, http.OK, len(data), None)
 		return True
 
 


### PR DESCRIPTION
This fix resolves a bug in the station and event service when data is requested in text format, e.g.
 http://geofon.gfz-potsdam.de/fdsnws/station/1/query?level=channel&format=text&network=*
