### PR TITLE
change: param name="includemagnitudes" >> "includeallmagnitudes"

### DIFF
--- a/src/trunk/apps/fdsnws/share/event.wadl
+++ b/src/trunk/apps/fdsnws/share/event.wadl
@@ -20,7 +20,7 @@
 					<param name="maxmagnitude" style="query" type="xsd:float"/>
 					<param name="magnitudetype" style="query" type="xsd:string"/>
 					<param name="includeallorigins" style="query" type="xsd:boolean" default="false"/>
-					<param name="includemagnitudes" style="query" type="xsd:boolean" default="false"/>
+					<param name="includeallmagnitudes" style="query" type="xsd:boolean" default="false"/>
 					<param name="includearrivals" style="query" type="xsd:boolean" default="false"/>
 					<param name="eventid" style="query" repeating="true"/>
 					<param name="limit" style="query" type="xsd:int"/>


### PR DESCRIPTION
- this is the correct parameter name according to fdsn ws specification (http://www.fdsn.org/webservices/FDSN-WS-Specifications-1.1.pdf, page 5)
- this is also the parameter at it is actually implemented.