### PR TITLE
Bug for stations with elevation <-999 corrected

### DIFF
--- a/src/ipgp/plugins/locator/hypo71/hypo71.cpp
+++ b/src/ipgp/plugins/locator/hypo71/hypo71.cpp
@@ -1058,7 +1058,7 @@ Origin* Hypo71::locate(PickList& pickList) throw (Core::GeneralException) {
 			<< formatString(getSituation(sloc->longitude(), gpLongitude), 1, 0, "hemispheric situation")
 
 			//! station elevation //! integer 4
-			<< formatString(toString((int) sloc->elevation()).c_str(), 4, 0, "station elevation")
+			<< formatString(toString((int) (sloc->elevation() / toDouble(cRL.test20))).c_str(), 4, 0, "station elevation")
 
 			//! blank space
 			<< formatString("", 1, 0)
@@ -2403,7 +2403,7 @@ Hypo71::getZTR(const PickList& pickList) throw (Core::GeneralException) {
 				//! hemispheric station situation E/W //! Alphanumeric 1
 				<< formatString(getSituation(sloc->longitude(), gpLongitude), 1, 0, "hemispheric situation")
 				//! station elevation //! integer 4
-				<< formatString(toString((int) sloc->elevation()).c_str(), 4, 0, "station elevation")
+				<< formatString(toString((int) (sloc->elevation() / toDouble(cRL.test20))).c_str(), 4, 0, "station elevation")
 				//! blank space
 				<< formatString("", 1, 0)
 				//! station delay //! float 5.2


### PR DESCRIPTION
For station elevation below -999 meters, TEST(20) should be set to a value higher than 1, and station elevation in the HYPO71.INP file should be set to station_elevation / TEST(20).
For an OBS at -4523m (4523m below sea level), TEST(20) should be set at 10 and station elevation in the station list of HYPO71.INP should be set to -452. And all stations elevations in the HYPO71.INP file should be divided by 10.

TODO : make this intelligent by removing TEST(20) from the profile file, and setting it to 10 if one of the stations elevation is lower than -999.