### PR TITLE
Fix "other" event type

### DIFF
--- a/src/trunk/libs/seiscomp3/datamodel/types.h
+++ b/src/trunk/libs/seiscomp3/datamodel/types.h
@@ -261,7 +261,7 @@ MAKEENUM(
 		"plane crash",
 		"sonic boom",
 		"duplicate",
-		"other"
+		"other event"
 	)
 );
 


### PR DESCRIPTION
Hi,

Using fdsnws from SeisComP implementation, I got an issue. An event can be of the type "other" while this latter is not defined by QuakeML 1.2 while "other type" is an acceptable value. So currently, the webservice output won't validate, for example : 


>lxml.etree.XMLSyntaxError: Element '{http://quakeml.org/xmlns/bed/1.2}type': [facet 'enumeration'] The value 'other' is not an element of the set {'not existing', 'not reported', 'earthquake', 'anthropogenic event', 'collapse', 'cavity collapse', 'mine collapse', 'building collapse', 'explosion', 'accidental explosion', 'chemical explosion', 'controlled explosion', 'experimental explosion', 'industrial explosion', 'mining explosion', 'quarry blast', 'road cut', 'blasting levee', 'nuclear explosion', 'induced or triggered event', 'rock burst', 'reservoir loading', 'fluid injection', 'fluid extraction', 'crash', 'plane crash', 'train crash', 'boat crash', 'other event', 'atmospheric event', 'sonic boom', 'sonic blast', 'acoustic noise', 'thunder', 'avalanche', 'snow avalanche', 'debris avalanche', 'hydroacoustic event', 'ice quake', 'slide', 'landslide', 'rockslide', 'meteorite', 'volcanic eruption'}.

For existing database, the field event.m_type should be updated too :

```sql
UPDATE event SET m_type='other type' WHERE m_type='other';
```

Thank you in advance