### PR TITLE
add missing seiscomp3.System import

### DIFF
--- a/src/trunk/apps/python/scalert.py
+++ b/src/trunk/apps/python/scalert.py
@@ -13,7 +13,7 @@
 ############################################################################
 
 import os, sys, subprocess, traceback
-import seiscomp3.Client, seiscomp3.Seismology
+import seiscomp3.Client, seiscomp3.Seismology, seiscomp3.System
 
 class VoiceAlert(seiscomp3.Client.Application):
 


### PR DESCRIPTION
Fix missing seiscomp3.System import, that prevents scalert.py to  start properly.
