### PR TITLE
Allow adjacent epochs with 'touching' start/end times.

### DIFF
--- a/src/trunk/apps/tools/inventory/fdsnxml2inv/convert2sc3.cpp
+++ b/src/trunk/apps/tools/inventory/fdsnxml2inv/convert2sc3.cpp
@@ -163,7 +163,7 @@ pair<int,int> double2frac(double d) {
 
 // Special overlap check for time windows where end time might be open
 bool overlaps(const Core::TimeWindow &tw1, const Core::TimeWindow &tw2) {
-    if(tw2.startTime() < tw1.startTime()) return overlaps(tw2, tw1);
+    if ( tw2.startTime() < tw1.startTime() ) return overlaps(tw2, tw1);
     return !tw1.endTime().valid() || tw1.endTime() > tw2.startTime();
 }
 

--- a/src/trunk/apps/tools/inventory/fdsnxml2inv/convert2sc3.cpp
+++ b/src/trunk/apps/tools/inventory/fdsnxml2inv/convert2sc3.cpp
@@ -161,21 +161,10 @@ pair<int,int> double2frac(double d) {
 }
 
 
-bool contains(const Core::TimeWindow &tw, const Core::Time &time) {
-	if ( !time.valid() ) return false;
-	if ( tw.endTime().valid() )
-		return tw.contains(time);
-	return time >= tw.startTime();
-}
-
-
 // Special overlap check for time windows where end time might be open
 bool overlaps(const Core::TimeWindow &tw1, const Core::TimeWindow &tw2) {
-	if ( contains(tw1, tw2.startTime()) ) return true;
-	if ( contains(tw1, tw2.endTime()) ) return true;
-	if ( contains(tw2, tw1.startTime()) ) return true;
-	if ( contains(tw2, tw1.endTime()) ) return true;
-	return false;
+    if(tw2.startTime() < tw1.startTime()) return overlaps(tw2, tw1);
+    return !tw1.endTime().valid() || tw1.endTime() > tw2.startTime();
 }
 
 

--- a/src/trunk/libs/seiscomp3/core/timewindow.h
+++ b/src/trunk/libs/seiscomp3/core/timewindow.h
@@ -157,7 +157,7 @@ inline void TimeWindow::setLength(double length)
 
 inline bool TimeWindow::contains(const Time &t) const
 {
-	return t >= _startTime && t <= _endTime;
+	return t >= _startTime && t < _endTime;
 }
 
 inline bool TimeWindow::contains(const TimeWindow &tw) const


### PR DESCRIPTION
 - Previously, adjacent epochs where the end time
   of the first and start time of the second are
   identical were considered overlapping and skipped
   in fdsnxml2inv.

 - The change to TimeWindow::contains is not required
   for the fix, but I have not looked where or how it is
   used and it may be required for consistency. Nor have
   I checked whether other changes are required.