### PR TITLE
Added %time interpolation for dataselect filename

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/dataselect.py
+++ b/src/trunk/apps/fdsnws/fdsnws/dataselect.py
@@ -417,7 +417,7 @@ class FDSNDataSelect(resource.Resource):
 								    False, "", True, [], "fdsnws", "OK", 0, "")
 
 		# Build output filename
-		fileName = Application.Instance()._fileNamePrefix+'.mseed'
+		fileName = Application.Instance()._fileNamePrefix.replace("%time", time.strftime('%Y-%m-%dT%H:%M:%S'))+'.mseed'
 
 		# Create producer for async IO
 		req.registerProducer(_WaveformProducer(req, ro, rs, fileName, tracker), False)


### PR DESCRIPTION
Hi devs, for our default fdsnws-dataselect exporting name we will add the current request time. If you are interested you can merge this pull request. It interpolates `%time` in `fdsnws.cfg:fileNamePrefix` to the current time in ISO-format.

`fileNamePrefix = fdsnws-%time` results in `fdsnws-2017-01-16T16_38_39.mseed`.