### PR TITLE
Fixes a bug in scvsmag with preferred origins without arrivals (second try).

### DIFF
--- a/src/sed/apps/scvsmag/scvsmag.cpp
+++ b/src/sed/apps/scvsmag/scvsmag.cpp
@@ -609,6 +609,12 @@ void VsMagnitude::handleEvent(Event *event) {
 	if ( _expirationTimeReference == "ot" )
 		vsevent->expirationTime = org->time().value() + Core::TimeSpan(_eventExpirationTime, 0);
 
+	/// if no arrival then no Mvs, but expiration time is updated
+	if ( org->arrivalCount() == 0 ){
+		SEISCOMP_DEBUG("Ignoring current preferred origin %s (it has no arrival), but expiration time updated", org->publicID().c_str());
+		return;
+	}
+
 	/// Generate some statistics for later use in delta-pick quality measure
 	Timeline::StationList pickedThresholdStations; // all picked stations at a limited distance from the epicenter
 	vsevent->pickedStations.clear();


### PR DESCRIPTION
Before this, preferred origins that have no arrival would crash scvsmag when using OriginQuality.azimuthalGap.

Now, if it has no arrival, scvsmag exits without doing Mvs, but VS's expirationTime is updated (using the current preferred origin).

This was [issue 92](https://github.com/SeisComP3/seiscomp3/issues/92), this is the second try I closed the first.