### PR TITLE
[scshowevent] commandline utility to send notifications to scolv to show event details 

### DIFF
--- a/src/gui-qt4/apps/scshowevent/CMakeLists.txt
+++ b/src/gui-qt4/apps/scshowevent/CMakeLists.txt
@@ -1,0 +1,20 @@
+SET(PACKAGE_NAME SHOWEVENT)
+SET(APP_NAME scshowevent)
+
+SET(
+    ${PACKAGE_NAME}_SOURCES
+        main.cpp
+        sendevent.cpp
+)
+
+SET(
+    ${PACKAGE_NAME}_MOC_HEADERS
+        sendevent.h
+)
+
+SC_ADD_GUI_EXECUTABLE(${PACKAGE_NAME} ${APP_NAME})
+SC_LINK_LIBRARIES_INTERNAL(${APP_NAME} qt4)
+
+FILE(GLOB descs "${CMAKE_CURRENT_SOURCE_DIR}/descriptions/*.xml")
+INSTALL(FILES ${descs} DESTINATION ${SC3_PACKAGE_APP_DESC_DIR})
+

--- a/src/gui-qt4/apps/scshowevent/main.cpp
+++ b/src/gui-qt4/apps/scshowevent/main.cpp
@@ -1,0 +1,36 @@
+/***************************************************************************
+ *   Copyright (C) by ASGSR
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+#include <iostream>
+
+#include "sendevent.h"
+
+
+using namespace std;
+using namespace Seiscomp;
+using namespace Seiscomp::Gui;
+
+/*
+ * Usage: scsendevent -E <eventID> 
+ *        otherwise type: sctestclient --help
+ */
+int main(int argc, char* argv[])
+{
+	Application::Type type = QApplication::Tty;
+
+	SendEvent app(argc, argv, type);
+	
+	return app();
+}
+
+
+

--- a/src/gui-qt4/apps/scshowevent/sendevent.cpp
+++ b/src/gui-qt4/apps/scshowevent/sendevent.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************
+ *   Copyright (C) by ASGSR
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+#define SEISCOMP_COMPONENT SendEvent
+
+
+
+#include <seiscomp3/datamodel/event.h>
+#include <seiscomp3/gui/core/application.h>
+#include <seiscomp3/gui/core/messages.h>
+#include <seiscomp3/logging/log.h>
+
+#include "sendevent.h"
+
+
+using namespace std;
+using namespace Seiscomp;
+using namespace Seiscomp::Communication;
+using namespace Seiscomp::DataModel;
+using namespace Seiscomp::Gui;
+
+
+SendEvent::SendEvent(int& argc, char **argv, Seiscomp::Gui::Application::Type type)
+: Application(argc, argv, 0, type) {
+	setMessagingEnabled(true);
+	setMessagingUsername("scsendevt");
+	setDatabaseEnabled(true,false);
+	setRecordStreamEnabled(false);
+	setLoadRegionsEnabled(false);
+	setLoadCitiesEnabled(false);
+	addLoggingComponentSubscription("Application");
+	setPrimaryMessagingGroup(Communication::Protocol::LISTENER_GROUP);
+}
+
+
+bool SendEvent::run() {
+
+        if ( !_eventID.empty() ) {
+
+        	PublicObjectPtr po = SCApp->query()->loadObject(Event::TypeInfo(), _eventID);
+        	EventPtr e = Event::Cast(po);
+        	if ( !e ) {
+			SEISCOMP_WARNING("Event %s has not been found.\n", _eventID.c_str());
+			cerr << "Warning: EventID " << _eventID.c_str() << " has not been found.\n";
+                	return false;
+        	}
+
+		// Workaround for not to open window QMessageBox in the Application::sendCommand
+		// when application is commandline
+		if ( commandTarget().empty() && SCApp->type() == QApplication::Tty ) {
+                	cerr << "WARNING: \n"
+                            "\tVariable <commands.target> is not set. To disable sending commands \n"
+                            "\tto all connected clients, set a proper target. You can use \n"
+                            "\tregular expressions to specify a group of clients (HINT: all = '.*$').\n\n";
+                	return false;
+		}
+
+        	SCApp->sendCommand(Gui::CM_SHOW_ORIGIN, e->preferredOriginID());
+		return true;
+	} 
+
+	cerr << "must specify event using '-E eventID'\n";
+	return false;
+}
+
+
+void SendEvent::createCommandLineDescription() {
+	commandline().addGroup("Options");
+	commandline().addOption("Options", "event-id,E", "eventID to show details", &_eventID, false);
+}
+

--- a/src/gui-qt4/apps/scshowevent/sendevent.h
+++ b/src/gui-qt4/apps/scshowevent/sendevent.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *   Copyright (C) by ASGSR
+ *                                                                         *
+ *   You can redistribute and/or modify this program under the             *
+ *   terms of the SeisComP Public License.                                 *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   SeisComP Public License for more details.                             *
+ ***************************************************************************/
+
+#ifndef __SEISCOMP_GUI_SENDEVENT_H__
+#define __SEISCOMP_GUI_SENDEVENT_H__
+
+#include <seiscomp3/gui/core/application.h>
+#ifndef Q_MOC_RUN
+#include <seiscomp3/datamodel/origin.h>
+#endif
+#include <string.h>
+
+
+class SendEvent : public Seiscomp::Gui::Application {
+	Q_OBJECT
+
+	public:
+		SendEvent(int& argc, char **argv, Seiscomp::Gui::Application::Type);
+
+		void createCommandLineDescription();
+
+		bool run();
+
+
+//	private slots:
+
+
+	private:
+
+		std::string _eventID;
+
+};
+
+#endif


### PR DESCRIPTION
Small commandline utility to send notification to scolv to show event details.

Usage: scsendevent -E  \<eventID\>

Variable <commands.target> should be set to appropriate value. You can use
regular expressions to specify a group of clients (HINT: all = '.*$').