### PR TITLE
Fix scamp reprocessing

### DIFF
--- a/src/trunk/apps/processing/scamp/amptool.cpp
+++ b/src/trunk/apps/processing/scamp/amptool.cpp
@@ -300,7 +300,7 @@ bool AmpTool::run() {
 		if ( endTime.valid() )
 			 dbQuery += " and Pick." + _T("time_value") + "<'" + endTime.toString("%F %T") + "'";
 
-		dbQuery += " group by Amplitude." + _T("pickID");
+		dbQuery += " group by PPick." + _T("publicID") + ", Pick._oid";
 
 		if ( !commandline().hasOption("commit") )
 			_testMode = true;


### PR DESCRIPTION
The `scamp` reprocessing doesn't work with PostgreSQL (see logs). Replacing 

```
dbQuery += " group by Amplitude." + _T("pickID");
```

by

```
dbQuery += " group by PPick." + _T("publicID") + ", Pick._oid";
```

is working for me. I try with PostgreSQL but not with MySQL so it may crash with MySQL.

Logs:

```
$ seiscomp exec scamp --debug --start-time '2016-03-06 00:00:00' --end-time '2016-03-08 00:00:00' --commit
15:24:50 [debug] Adding plugin path: .
15:24:50 [debug] Adding plugin path: /home/seiscomp/.seiscomp3/plugins
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/lib/plugins
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/lib
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/share/plugins
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/lib
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/lib
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/lib
15:24:50 [debug] Adding plugin path: /home/seiscomp/Applications/seiscomp3/share/plugins/scamp
15:24:50 [debug] Trying to open plugin at /home/seiscomp/Applications/seiscomp3/share/plugins/dbpostgresql.so
15:24:50 [info] Plugin dbpostgresql registered
15:24:50 [info]
Plugins:
--------
 [1]
  description: PostgreSQL database driver
       author: GFZ Potsdam <seiscomp-devel@gfz-potsdam.de>
      version: 0.9.1
          API: 9.0.0

15:24:50 [info] Connect to messaging
15:24:50 [debug] Trying to connect to sysop@localhost with primary group = AMPLITUDE
15:24:50 [info] Connecting to server: localhost
15:24:50 [info] Connected to message server: localhost
15:24:50 [info] Joining MASTER_GROUP group
15:24:50 [info] Sending connect message to server: localhost
15:24:51 [info] Server version is 'Jakarta 2016.333'
15:24:51 [info] Outgoing messages are encoded to match schema version 0.9
15:24:51 [info] user "sysop" connected successfully to localhost
15:24:51 [info] Setting message encoding to binary
15:24:51 [info] Joining group: AMPLITUDE
15:24:51 [info] Joining group: LOCATION
15:24:51 [info] Joining group: PICK
15:24:51 [info] Connect to database
15:24:51 [info] Received database service parameters
15:24:51 [info] Trying to connect to postgresql://sysop:sysop@localhost/seiscomp3
15:24:51 [debug] Found database version v0.9
15:24:51 [info] Connected successfully
15:24:51 [info] Loading complete inventory
15:24:55 [info] Finished loading complete inventory
15:24:55 [info] Loading configuration module
15:24:55 [info] Finished loading configuration module
15:24:55 [debug] trying to open stream arclink://localhost:18001
15:24:55 [info]
Amplitudes to calculate:
 * MLv: OK
 * Mwp: OK
 * mB: OK
 * mb: OK

Collecting picks ... 15:24:55 [error] QUERY/COMMAND failed
15:24:55 [error]   select PPick.m_publicID, Pick.* from Pick,PublicObject as PPick,Amplitude where Pick._oid=PPick._oid and Amplitude.m_pickID=PPick.m_publicID and Pick.m_time_value>='2016-03-06 00:00:00' and Pick.m_time_value<'2016-03-08 00:00:00' group by Amplitude.m_pickID
15:24:55 [error]   ERROR:  column "ppick.m_publicid" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: select PPick.m_publicID, Pick.* from Pick,PublicObject as PP...
               ^

15:24:55 [error] starting query 'select PPick.m_publicID, Pick.* from Pick,PublicObject as PPick,Amplitude where Pick._oid=PPick._oid and Amplitude.m_pickID=PPick.m_publicID and Pick.m_time_value>='2016-03-06 00:00:00' and Pick.m_time_value<'2016-03-08 00:00:00' group by Amplitude.m_pickID' failed
0
----------------------------------
Recomputed 0 amplitudes
Sent 0 messages
15:24:55 [debug] Leaving ::done
```