### PR TITLE
Fixes the lack of precision in MVS creationTime.

### DIFF
--- a/src/sed/apps/scvsmag/scvsmag.cpp
+++ b/src/sed/apps/scvsmag/scvsmag.cpp
@@ -862,7 +862,7 @@ void VsMagnitude::process(VsEvent *evt, Event *event) {
 
 		// Record single station magnitudes
 		Notifier::SetEnabled(true);
-		_creationInfo.setCreationTime(_currentTime);
+		_creationInfo.setCreationTime(Core::Time::GMT()); // was "_currentTime);" before but didn't allow sub-second precision.
 		_creationInfo.setModificationTime(Core::None);
 		DataModel::StationMagnitudePtr staMag = DataModel::StationMagnitude::Create();
 		staMag->setMagnitude(RealQuantity(input.mest));
@@ -1072,7 +1072,7 @@ void VsMagnitude::updateVSMagnitude(Event *event, VsEvent *vsevt) {
 	}
 
 	Notifier::SetEnabled(true);
-	_creationInfo.setCreationTime(_currentTime);
+	_creationInfo.setCreationTime(Core::Time::GMT()); // was "_currentTime);" before but didn't allow sub-second precision.
 	_creationInfo.setModificationTime(Core::None);
 	_creationInfo.setVersion(Core::toString(vsevt->update));
 	MagnitudePtr nmag = Magnitude::Create();
@@ -1128,7 +1128,7 @@ bool VsMagnitude::setComments(Magnitude *mag, const std::string id,
 	cmt->setId(id);
 	cmt->setText(Core::toString(value));
 	CreationInfo ci;
-	ci.setCreationTime(_currentTime);
+	ci.setCreationTime(Core::Time::GMT()); // was "_currentTime);" before but didn't allow sub-second precision.
 	cmt->setCreationInfo(ci);
 
 	if ( !mag->add(cmt.get()) ) {


### PR DESCRIPTION
Before all MVS children objects would have a precision of 1.0s in
creation times. This is wrong since the corresponding origin sometimes
appears to be created after its magnitude, e.g.:

    <origin publicID="Origin#20161103054840.154469.2647">                        ...
      <creationInfo>                                                             ...
        <creationTime>2016-11-03T05:48:40.154452Z</creationTime>
      </creationInfo>                                                            ...
      <stationMagnitude publicID="StationMagnitude#20161103054841.032559.49535"> ...
        <creationInfo>                                                           ...
          <creationTime>2016-11-03T05:48:40.0000Z</creationTime>
          <version>10</version>
        </creationInfo>
      </stationMagnitude>                                                        ...
      <magnitude publicID="Magnitude#20161103054841.090017.49560">               ...
        <creationInfo>                                                           ...
          <creationTime>2016-11-03T05:48:40.0000Z</creationTime>                 ...
        </creationInfo>
        <comment>                                                                ...
          <creationInfo>
            <creationTime>2016-11-03T05:48:40.0000Z</creationTime>
          </creationInfo>
        </comment>                                                               ...

In this example "..." means the sc3xml structure has been trimmed.

I switched `setCreationTime(_currentTime)` by
`setCreationTime( Core::Time::GMT() )` with the disadvantage of time
stamping a few steps after the actual magnitude computation.

Now the creation times of all scvsmag children objects have
sub-second precisions. And the creation order stays how it show be: origin,
then stationMagnitude, then magnitude.