### PR TITLE
Add argument "type" to MLv amplitude processor constructors.

### DIFF
--- a/src/trunk/libs/seiscomp3/processing/amplitudes/MLv.cpp
+++ b/src/trunk/libs/seiscomp3/processing/amplitudes/MLv.cpp
@@ -35,8 +35,8 @@ REGISTER_AMPLITUDEPROCESSOR(AmplitudeProcessor_MLv, "MLv");
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-AmplitudeProcessor_MLv::AmplitudeProcessor_MLv()
-	: AmplitudeProcessor("MLv") {
+AmplitudeProcessor_MLv::AmplitudeProcessor_MLv(const std::string& type)
+	: AmplitudeProcessor(type) {
 	setSignalEnd(150.);
 	setMinSNR(0);
 	setMaxDist(8);
@@ -48,8 +48,8 @@ AmplitudeProcessor_MLv::AmplitudeProcessor_MLv()
 
 
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-AmplitudeProcessor_MLv::AmplitudeProcessor_MLv(const Core::Time& trigger)
-	: AmplitudeProcessor(trigger, "MLv") {
+AmplitudeProcessor_MLv::AmplitudeProcessor_MLv(const Core::Time& trigger, const std::string& type)
+	: AmplitudeProcessor(trigger, type) {
 	setSignalEnd(150.);
 	setMinSNR(0);
 	setMaxDist(8);

--- a/src/trunk/libs/seiscomp3/processing/amplitudes/MLv.h
+++ b/src/trunk/libs/seiscomp3/processing/amplitudes/MLv.h
@@ -27,8 +27,8 @@ class SC_SYSTEM_CLIENT_API AmplitudeProcessor_MLv : public AmplitudeProcessor {
 	DECLARE_SC_CLASS(AmplitudeProcessor_MLv);
 
 	public:
-		AmplitudeProcessor_MLv();
-		AmplitudeProcessor_MLv(const Core::Time& trigger);
+		explicit AmplitudeProcessor_MLv(const std::string& type="MLv");
+		AmplitudeProcessor_MLv(const Core::Time& trigger, const std::string& type="MLv");
 
 	public:
 		virtual void initFilter(double fsamp);


### PR DESCRIPTION
 So we can inherit from it.