### PR TITLE
Fix scvsmag when processing NaN stationmagnitude

### DIFF
--- a/src/sed/apps/scvsmag/scvsmag.cpp
+++ b/src/sed/apps/scvsmag/scvsmag.cpp
@@ -927,6 +927,10 @@ void VsMagnitude::process(VsEvent *evt, Event *event) {
 
 		for ( size_t i = 0; i < inputs.size(); ++i ) {
 			const VsInput &input = inputs[i];
+			
+			if ( Math::isNaN(input.mest)  ) {
+                                continue ;
+                        }
 
 			// Likelihood
 			vs.setmag(mag);


### PR DESCRIPTION
The VS code calculates both individual station magnitudes and a global magnitude, the latest being inferred together with the likelihood in a loop here:
https://github.com/SeisComP3/seiscomp3/blob/02f18cf1479a13eca385f6ec42681f335b5d8f97/src/sed/apps/scvsmag/scvsmag.cpp#L925

This loop goes from M0.5 to M9.0 and is supposed to pick the global VS magnitude at the likelihood peak. To do so a conditional record of the last trial magnitude breaks when the likelihood starts to decrease and the magnitude at highest likelihood is recorded. Note this loop make use of a sum of likelihood over all available individual station magnitude in a nested loop.

During large earthquakes, some stations (the clipped ones?) have PG*=-1 and stationmagnitude=nan. These can't be processed in scvsmag and result in global Mvs equal to 0.5 (although the median station magnitude is much higher).

So, as a quick fix, I guess NaN station magnitudes could be excluded from the global Mvs estimation loop so NaN won’t destroy the sums it make use of. 

But maybe clipped stations are not tagged correctly in scenvelope?