### PR TITLE
[Hypo71PC] bug when starting point fixed

### DIFF
--- a/src/ipgp/apps/3rd-party/Hypo71PC/hypo1m2.f
+++ b/src/ipgp/apps/3rd-party/Hypo71PC/hypo1m2.f
@@ -288,7 +288,7 @@ c     IF (IEW(JI) .EQ. 'E') DXI=-DXI
    54 FORMAT(' ***** FOLLOWING EVENT IS OUT OF ORDER *****')            
    60 IF ((KP.EQ.1) .AND. (IPRN.EQ.0)) GO TO 67                         
       IF (IPH .EQ. 1) GO TO 62                                          
-      WRITE(8,61) INS(1),IEW(1)                                        
+      WRITE(8,61) INS(1),IEW(1)
    61 FORMAT(/,59X,'  ADJUSTMENTS (KM)  PARTIAL F-VALUES  STANDARD '
      +,'ERRORS  ADJUSTMENTS TAKEN',/
      +,'  I  ORIG  LAT ',A1                      

--- a/src/ipgp/apps/3rd-party/Hypo71PC/input1.f
+++ b/src/ipgp/apps/3rd-party/Hypo71PC/input1.f
@@ -225,12 +225,12 @@ C------- INPUT CONTROL CARD --------------------------------------------
   200 WRITE(8,205)                                                      
   205 FORMAT(///,1x,'KS Z XNEAR XFAR  POS   IQ  KMS  KFM IPUN IMAG   IR'   
      1,' IPRN CODE   LATR      LONR')                                   
-      read(12,215) KSING,ZTR,XNEAR,XFAR,POS,IQ,KMS,KFM,IPUN,IMAG,IR,IPRN
-     1,KPAPER,KTEST,KAZ,KSORT,KSEL,LAT1,LAT2,LON1,LON2                  
+      read(12,215) KSING,ZTR,XNEAR,XFAR,POS,IQ,KMS,KFM,IPUN,IMAG,IR,
+     1 IPRN,KPAPER,KTEST,KAZ,KSORT,KSEL,LAT1,LAT2,LON1,LON2             
   215 FORMAT(I1,F4.0,2F5.0,F5.2,7I5,5I1,2(I4,F6.2))                     
 c 215 FORMAT(I1,F5.0,2F6.0,F5.2,7I5,5I1,2(I4,F6.2))                     
-       WRITE(8,218) KSING,ZTR,XNEAR,XFAR,POS,IQ,KMS,KFM,IPUN,IMAG,IR,IPRN
-     1,KPAPER,KTEST,KAZ,KSORT,KSEL,LAT1,LAT2,LON1,LON2                  
+       WRITE(8,218) KSING,ZTR,XNEAR,XFAR,POS,IQ,KMS,KFM,IPUN,IMAG,IR,
+     1 IPRN,KPAPER,KTEST,KAZ,KSORT,KSEL,LAT1,LAT2,LON1,LON2           
   218 FORMAT(1X,I1,F4.0,2F5.0,F5.2,7I5,5I1,2(I4,F6.2))                  
       LATR=60.*LAT1+LAT2                                                
       LONR=60.*LON1+LON2                                                

--- a/src/ipgp/apps/3rd-party/Hypo71PC/single.f
+++ b/src/ipgp/apps/3rd-party/Hypo71PC/single.f
@@ -124,10 +124,14 @@ c     endif
       IF(LATRT.EQ.0.) GO TO 102
       LATEP=LATRT
       LONEP=LONRT
+      IF(iew(1).EQ.'W')LonEp=-LonEp
+      IF(ins(1).EQ.'S')LatEp=-LatEp
       GO TO 105
   102 IF (LATR .EQ. 0.) GO TO 104
       LATEP=LATR
       LONEP=LONR
+      IF(iEW(1).EQ.'W')LonEp=-LonEp
+      IF(ins(1).EQ.'S')LatEp=-LatEp
       GO TO 105
   104 LATEP=LAT(K)+0.1
       LONEP=LON(K)+0.1


### PR DESCRIPTION
Longitude 0/180 bug correction forgot the case when a fixed starting point of the iteration was passed (option USE_TRIAL_POSITION set to true in the profile)