### PR TITLE
Fix XSLT files for SC3ML 0.10

### DIFF
--- a/src/trunk/libs/xml/0.10/sc3ml_0.10__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.10/sc3ml_0.10__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.10 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -110,6 +110,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -164,6 +168,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -224,6 +232,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -236,6 +246,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -384,7 +395,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.10/sc3ml_0.10__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.10 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.5/sc3ml_0.5__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.5/sc3ml_0.5__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.5 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -110,6 +110,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -164,6 +168,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -224,6 +232,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -236,6 +246,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -384,7 +395,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.5/sc3ml_0.5__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.5/sc3ml_0.5__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.5 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.6/sc3ml_0.6__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.6/sc3ml_0.6__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.6 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -113,6 +113,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -167,6 +171,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -227,6 +235,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -239,6 +249,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -387,7 +398,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.6/sc3ml_0.6__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.6 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.7/sc3ml_0.7__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.7/sc3ml_0.7__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.7 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -110,6 +110,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -164,6 +168,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -224,6 +232,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -236,6 +246,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -384,7 +395,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.7/sc3ml_0.7__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.7 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.8/sc3ml_0.8__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.8/sc3ml_0.8__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.8 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -110,6 +110,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -164,6 +168,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -224,6 +232,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -236,6 +246,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -384,7 +395,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.8/sc3ml_0.8__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.8 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.9/sc3ml_0.9__quakeml_1.2-RT.xsl
+++ b/src/trunk/libs/xml/0.9/sc3ml_0.9__quakeml_1.2-RT.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.9 to QuakeML 1.2 RT stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -110,6 +110,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -164,6 +168,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -224,6 +232,8 @@
     <!-- Delete elements -->
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -236,6 +246,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
 
     <!-- event -->
@@ -384,7 +395,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>

--- a/src/trunk/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.9/sc3ml_0.9__quakeml_1.2.xsl
@@ -18,7 +18,7 @@
  * SC3ML 0.9 to QuakeML 1.2 stylesheet converter
  * Author  : Stephan Herrnkind
  * Email   : stephan.herrnkind@gempa.de
- * Version : 2017.270.01
+ * Version : 2017.342.01
  *
  * ================
  * Usage
@@ -105,6 +105,10 @@
  *                    cmtVersion
  *                    phaseSetting
  *    eventParameters reading
+ *    comment         start
+ *    comment         end
+ *    RealQuantity    pdf
+ *    TimeQuality     pdf
  *
  *  - Mandatory nodes: The following nodes is mandatory in QuakeML but not in
  *    SC3ML:
@@ -159,6 +163,10 @@
  *    - Map SC3 arrival weight to timeWeight, horizontalSlownessWeight and
  *      backazimuthWeight depending on timeUsed, horizontalUsed and
  *      backzimuthUsed values
+ *
+ *  * 08.12.2017:
+ *    - Remove unmapped nodes
+ *    - Fix arrival weight mapping
  *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
@@ -264,6 +272,8 @@
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
     <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
+    <xsl:template match="scs:comment/scs:start"/>
+    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -276,6 +286,7 @@
     <xsl:template match="scs:momentTensor/scs:cmtName"/>
     <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
     <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
+    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -403,7 +414,8 @@
                  depending on timeUsed, horizontalSlownessUsed and backazimuthUsed values -->
             <xsl:choose>
                 <xsl:when test="scs:weight">
-                    <xsl:if test="((not(scs:timeUsed)) or (scs:timeUsed='true') or (scs:timeUsed='1'))">
+                    <xsl:if test="((scs:timeUsed='true') or (scs:timeUsed='1'))
+                                  or (not(scs:timeUsed|scs:horizontalSlownessUsed|scs:backazimuthUsed))">
                         <xsl:element name="timeWeight">
                             <xsl:value-of select="scs:weight"/>
                         </xsl:element>


### PR DESCRIPTION
I was looking to update the SC3ML ObsPy module with the 0.10 version but the XSLT files doesn't generate valid QuakeML files. The following new fields aren't in the QuakeML:
- Comment/start
- Comment/end
- TimeQuantity/pdf
- RealQuantity/pdf

I don't think they have a corresponding node in the QuakeML so I removed them. I also add a small fix for the arrival weight mapping.

I mainly tested the conversion to the QuakeML format. QuakeML-RT seems good but I didn't test a lot. Let me know if I did something wrong!