### PR TITLE
Add an origin time hint in the AmplitudeProcessor

### DIFF
--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/amplitudeview.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/amplitudeview.cpp
@@ -3797,6 +3797,11 @@ RecordViewItem* AmplitudeView::addRawStream(const DataModel::SensorLocation *loc
 
 	label->processor->setHint(Processing::WaveformProcessor::Distance, delta);
 
+	try {
+		label->processor->setHint(Processing::WaveformProcessor::Time, (double) _origin->time().value());
+	}
+	catch ( ... ) {}
+
 	label->processor->computeTimeWindow();
 
 	label->timeWindow.set(referenceTime+Core::TimeSpan(label->processor->config().noiseBegin-_config.preOffset),

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/calculateamplitudes.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/calculateamplitudes.cpp
@@ -575,6 +575,17 @@ void CalculateAmplitudes::addProcessor(
 		return;
 	}
 
+	try {
+		proc->setHint(WaveformProcessor::Time, (double) _origin->time().value());
+		if ( proc->isFinished() ) {
+			pair<TableRowMap::iterator, TableRowMap::iterator> itp = _rows.equal_range(proc.get());
+			for ( TableRowMap::iterator row_it = itp.first; row_it != itp.second; ++row_it )
+				setError(row_it->second, QString("%1 (%2)").arg(proc->status().toString()).arg(proc->statusValue(), 0, 'f', 2));
+			return;
+		}
+	}
+	catch ( ... ) {}
+
 	proc->computeTimeWindow();
 
 	switch ( proc->usedComponent() ) {

--- a/src/trunk/apps/processing/scamp/amptool.cpp
+++ b/src/trunk/apps/processing/scamp/amptool.cpp
@@ -394,7 +394,7 @@ bool AmpTool::run() {
 					proc->setReferencingPickID(pick->publicID());
 					proc->setPublishFunction(boost::bind(&AmpTool::storeLocalAmplitude, this, _1, _2));
 					_report << "     + Data" << std::endl;
-					addProcessor(proc.get(), pick.get(), None, None);
+					addProcessor(proc.get(), pick.get(), None, None, None);
 				}
 
 				cerr << endl;
@@ -763,7 +763,7 @@ void AmpTool::process(Origin *origin) {
 			proc->setTrigger(pickTime);
 			proc->setReferencingPickID(pickID);
 
-			int res = addProcessor(proc.get(), pick.get(), distance, depth);
+			int res = addProcessor(proc.get(), pick.get(), distance, depth, (double) origin->time().value());
 			if ( res < 0 ) {
 				// RecordStream not available
 				if ( res == -2 ) return;
@@ -817,7 +817,7 @@ void AmpTool::process(Origin *origin) {
 // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 int AmpTool::addProcessor(Processing::AmplitudeProcessor *proc,
                           const DataModel::Pick *pick,
-                          OPT(double) distance, OPT(double) depth) {
+                          OPT(double) distance, OPT(double) depth, OPT(double) originTime) {
 	WaveformProcessor::Component components[3];
 	int componentCount = 0;
 
@@ -962,6 +962,14 @@ int AmpTool::addProcessor(Processing::AmplitudeProcessor *proc,
 
 	if ( distance ) {
 		proc->setHint(WaveformProcessor::Distance, *distance);
+		if ( proc->isFinished() ) {
+			_report << "     - " << proc->type() << " [" << proc->status().toString() << " (" << proc->statusValue() << ")]" << std::endl;
+			return -1;
+		}
+	}
+
+	if ( originTime ) {
+		proc->setHint(WaveformProcessor::Time, *originTime);
 		if ( proc->isFinished() ) {
 			_report << "     - " << proc->type() << " [" << proc->status().toString() << " (" << proc->statusValue() << ")]" << std::endl;
 			return -1;

--- a/src/trunk/apps/processing/scamp/amptool.h
+++ b/src/trunk/apps/processing/scamp/amptool.h
@@ -83,7 +83,7 @@ class AmpTool : public Seiscomp::Client::StreamApplication {
 
 		int addProcessor(Seiscomp::Processing::AmplitudeProcessor *,
 		                 const Seiscomp::DataModel::Pick *pick,
-		                 OPT(double) distance, OPT(double) depth);
+		                 OPT(double) distance, OPT(double) depth, OPT(double) originTime);
 
 		size_t loadAmplitudes(const std::string &pickID,
 		                      Seiscomp::DataModel::Amplitude *ignoreAmp = NULL);

--- a/src/trunk/libs/seiscomp3/processing/waveformprocessor.h
+++ b/src/trunk/libs/seiscomp3/processing/waveformprocessor.h
@@ -57,7 +57,8 @@ class SC_SYSTEM_CLIENT_API WaveformProcessor : public Processor {
 
 		enum ProcessingHint {
 			Distance,
-			Depth
+			Depth,
+			Time
 		};
 
 		MAKEENUM(


### PR DESCRIPTION
I did a [magnitude plugin](https://forum.seiscomp3.org/t/custom-magnitude-plugin/705) which calculate a magnitude in the `AmplitudeProcessor` since this magnitude doesn't need amplitudes. However, I need the origin distance, depth but also the origin time. Is it possible to add an hint with the origin time?

I did the changes and it works but I may forgot some things.