### PR TITLE
[scevent]: allow scevent to clear its cache via messaging system

### DIFF
--- a/src/trunk/apps/processing/scevent/eventtool.h
+++ b/src/trunk/apps/processing/scevent/eventtool.h
@@ -219,6 +219,7 @@ class EventTool : public Application {
 		double                        _fExpiry;
 		Cache                         _cache;
 		bool                          _testMode;
+		bool                          _sendClearCache;
 		Util::StopWatch               _timer;
 		std::string                   _originID;
 		std::string                   _eventID;


### PR DESCRIPTION
This is useful to allow external applications writing external origins to the database and associating as additional origin to the seiscomp3 solution of the same event, to properly work in scolv.

Due to the  events caching a new origin in the database is not seen by scevent and this prevent few operations to be properbly completed in scolv:
- setting an external origin as preferred
- moving an external origin to another event