### PR TITLE
Fix no data 500

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/event.py
+++ b/src/trunk/apps/fdsnws/fdsnws/event.py
@@ -240,10 +240,10 @@ class FDSNEvent(resource.Resource):
 			Logging.warning(str(e))
 			return HTTP.renderErrorPage(req, http.BAD_REQUEST, str(e), ro)
 
-		# Catalog filter is not supported, any filter value will result in 204
+		# Catalog filter is not supported
 		if ro.catalogs:
-			msg = "no matching events found"
-			return HTTP.renderErrorPage(req, http.NO_CONTENT, msg, ro)
+			msg = "catalog filter not supported"
+			return HTTP.renderErrorPage(req, http.BAD_REQUEST, msg, ro)
 
 		# updateafter not implemented
 		if ro.updatedAfter:

--- a/src/trunk/apps/fdsnws/fdsnws/http.py
+++ b/src/trunk/apps/fdsnws/fdsnws/http.py
@@ -51,24 +51,31 @@ Service Version:
 %s
 """
 
+		noContent = code == http.NO_CONTENT
+
 		# rewrite response code if requested and no data was found
-		if ro is not None and code == http.NO_CONTENT:
+		if noContent and ro is not None:
 			code = ro.noData
 
-		# status code 204 requires no message body
+		# set response code
 		request.setResponseCode(code)
+
+		# status code 204 requires no message body
 		if code == http.NO_CONTENT:
-			return None
+			response = ""
+		else:
+			request.setHeader('Content-Type', 'text/plain')
 
-		request.setHeader('Content-Type', 'text/plain')
+			reference = "%s/" % (request.path.rpartition('/')[0])
 
-		reference = "%s/" % (request.path.rpartition('/')[0])
+			codeStr = http.RESPONSES[code]
+			date = Core.Time.GMT().toString("%FT%T.%f")
+			response = resp % (code, codeStr, msg, reference, request.uri, date,
+			                   VERSION)
+			if not noContent:
+				Logging.warning("responding with error: %i (%s)" % (
+				                code, codeStr))
 
-		codeStr = http.RESPONSES[code]
-		Logging.warning("responding with error: %i (%s)" % (code, codeStr))
-		date = Core.Time.GMT().toString("%FT%T.%f")
-		response = resp % (code, codeStr, msg, reference, request.uri, date,
-		                   VERSION)
 		utils.accessLog(request, ro, code, len(response), msg)
 		return response
 


### PR DESCRIPTION
This pull request is a response to #183 

A 204 response code requires an empty body. That's why a None was return in [fdsnws/http.py](https://github.com/SeisComP3/seiscomp3/blob/8a2dc6022429fe024e3b6c1f0ecacba2a02cc6af/src/trunk/apps/fdsnws/fdsnws/http.py#L61).
Twisted, however, turns a None response into a 500. I changed the None to an empty string.
In addition, and unrelated, I decided to no longer log 204 responses which have been converted to 404 via the request parameter `nodata=404` as a warning message.

Next I turn the 204 in response to a catalog filter parameter into a 400 since the service documentation as well as the WADL forbids this parameter.