### PR TITLE
Catch OSError on pgp.decryt

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/http.py
+++ b/src/trunk/apps/fdsnws/fdsnws/http.py
@@ -207,6 +207,11 @@ class AuthResource(resource.Resource):
 		try:
 			verified = self.__gpg.decrypt(request.content.getvalue())
 
+		except OSError, e:
+			msg = "gpg decrypt error"
+			Logging.warning("%s: %s" % (msg, str(e)))
+			return HTTP.renderErrorPage(request, http.INTERNAL_SERVER_ERROR, msg, None)
+		
 		except Exception, e:
 			msg = "invalid token"
 			Logging.warning("%s: %s" % (msg, str(e)))


### PR DESCRIPTION
It happened multiple times that gpg couldn't spawn a process due to a lack of memory on our system. The user sees this as `400` `Bad Request` while it is technically a server error. I added a catch for `OSError` that returns `500`.

Please review.