### PR TITLE
[scautoloc] Bugfix: correctly read config option autoloc.useManualPicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ magnitude correction. Note that **it only affects ML, not MLv and not MLh**.
 
   * Fix bug that caused autoloc.useManualOrigins to always be treated
     as true
+  * Fix bug that caused autoloc.useManualPicks to not be used as specified in
+    config but rather always treated as false (causing this option to only work
+    when calling scautoloc from command line with --use-manual-picks)
 
 * scdumpcfg
 

--- a/src/trunk/apps/processing/scautoloc/app.cpp
+++ b/src/trunk/apps/processing/scautoloc/app.cpp
@@ -269,6 +269,7 @@ bool App::initConfiguration() {
 
 	try { _config.minStaCountIgnorePKP = configGetInt("autoloc.minStaCountIgnorePKP"); } catch (...) {}
 	try { _config.reportAllPhases = configGetBool("autoloc.reportAllPhases"); } catch (...) {}
+	try { _config.useManualPicks = configGetBool("autoloc.useManualPicks"); } catch (...) {}
 	try { _config.useManualOrigins = configGetBool("autoloc.useManualOrigins"); } catch (...) {}
 	try { _config.useImportedOrigins = configGetBool("autoloc.useImportedOrigins"); } catch (...) {}
 

--- a/src/trunk/apps/processing/scautoloc/config.cpp
+++ b/src/trunk/apps/processing/scautoloc/config.cpp
@@ -168,6 +168,7 @@ void Autoloc3::Config::dump() const
 	SEISCOMP_INFO("offline                          %s",     offline ? "true":"false");
 	SEISCOMP_INFO("test                             %s",     test ? "true":"false");
 	SEISCOMP_INFO("playback                         %s",     playback ? "true":"false");
+	SEISCOMP_INFO("useManualPicks                   %s",     useManualPicks ? "true":"false");
 	SEISCOMP_INFO("useManualOrigins                 %s",     useManualOrigins ? "true":"false");
 // This isn't used still so we don't want to confuse the user....
 //	SEISCOMP_INFO("useImportedOrigins               %s",     useImportedOrigins ? "true":"false");


### PR DESCRIPTION
This option was always "false", regardless of what was specified in config files. The only way to get autoloc.useManualPicks set to "true" was by calling scautoloc on command line with option '--use-manual-picks'.

I think this PR should fix the bug, I can't check myself locally though, since I don't have time to set up compilation right now.