### PR TITLE
Copy picks referenced by amplitudes

### DIFF
--- a/src/trunk/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
@@ -174,6 +174,8 @@
  *
  *  * 02.11.2018: Don't export stationMagnitude passedQC attribute
  *
+ *  * 07.12.2018: Copy picks referenced by amplitudes
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -219,11 +221,17 @@
             <!-- search origins referenced by this event -->
             <xsl:for-each select="scs:originReference">
                 <xsl:for-each select="../../scs:origin[@publicID=current()]">
+                    <xsl:variable name="origin" select="current()" />
+
                     <!-- stationMagnitudes and referenced amplitudes -->
                     <xsl:for-each select="scs:stationMagnitude">
                         <xsl:for-each select="../../scs:amplitude[@publicID=current()/scs:amplitudeID]">
                             <!-- amplitude/genericAmplitude is mandatory in QuakeML -->
                             <xsl:if test="scs:amplitude">
+                                <!-- copy picks referenced in amplitudes -->
+                                <xsl:for-each select="../scs:pick[@publicID=current()/scs:pickID]">
+                                    <xsl:call-template name="genericNode" />
+                                </xsl:for-each>
                                 <xsl:call-template name="genericNode"/>
                             </xsl:if>
                         </xsl:for-each>
@@ -242,7 +250,12 @@
                     <!-- picks, referenced by arrivals -->
                     <xsl:for-each select="scs:arrival">
                         <!--xsl:value-of select="scs:pickID"/-->
-                        <xsl:for-each select="../../scs:pick[@publicID=current()/scs:pickID]">
+                        <!-- Don't copy picks already referenced in amplitudes -->
+                        <xsl:for-each select="
+                                ../../scs:pick[
+                                    @publicID=current()/scs:pickID
+                                    and not(@publicID=../scs:amplitude[
+                                        @publicID=$origin/scs:stationMagnitude/scs:amplitudeID]/scs:pickID)]">
                             <xsl:call-template name="genericNode"/>
                         </xsl:for-each>
                     </xsl:for-each>


### PR DESCRIPTION
If a pick wasn't referenced in an arrival but only in an amplitude, it wasn't retained in the XSLT conversion to QuakeML. Apparently, [this can happen](https://github.com/obspy/obspy/issues/2273).

This PR fixes that. All picks referenced by arrivals or amplitudes are kept. With the sample file provided in the ObsPy issue, I now have 7 picks as expected.