### PR TITLE
Use custom namespace to keep non-QuakeML nodes

### DIFF
--- a/src/trunk/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
+++ b/src/trunk/libs/xml/0.11/sc3ml_0.11__quakeml_1.2.xsl
@@ -176,6 +176,8 @@
  *
  *  * 07.12.2018: Copy picks referenced by amplitudes
  *
+ *  * 10.12.2018: Put the non-QuakeML nodes in a custom namespace
+ *
  ********************************************************************** -->
 <xsl:stylesheet version="1.0"
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -207,7 +209,10 @@
                         </xsl:call-template>
                     </xsl:attribute>
 
-                    <xsl:apply-templates/>
+                    <!-- Put the QuakeML nodes at the beginning -->
+                    <xsl:apply-templates select="*[not(self::scs:reading)]" />
+                    <!-- Put the non-QuakeML nodes at the end -->
+                    <xsl:apply-templates select="scs:reading" mode="scs-only" />
                 </eventParameters>
             </xsl:for-each>
         </q:quakeml>
@@ -284,15 +289,11 @@
     <!-- Delete elements -->
     <xsl:template match="scs:EventParameters/scs:pick"/>
     <xsl:template match="scs:EventParameters/scs:amplitude"/>
-    <xsl:template match="scs:EventParameters/scs:reading"/>
     <xsl:template match="scs:EventParameters/scs:origin"/>
     <xsl:template match="scs:EventParameters/scs:focalMechanism"/>
     <xsl:template match="scs:event/scs:originReference"/>
     <xsl:template match="scs:event/scs:focalMechanismReference"/>
-    <xsl:template match="scs:creationInfo/scs:modificationTime"/>
     <xsl:template match="scs:comment/scs:id"/>
-    <xsl:template match="scs:comment/scs:start"/>
-    <xsl:template match="scs:comment/scs:end"/>
     <xsl:template match="scs:arrival/scs:weight"/>
     <xsl:template match="scs:arrival/scs:timeUsed"/>
     <xsl:template match="scs:arrival/scs:horizontalSlownessUsed"/>
@@ -300,13 +301,6 @@
     <xsl:template match="scs:origin/scs:stationMagnitude"/>
     <xsl:template match="scs:origin/scs:magnitude"/>
     <xsl:template match="scs:momentTensor/scs:method"/>
-    <xsl:template match="scs:momentTensor/scs:stationMomentTensorContribution"/>
-    <xsl:template match="scs:momentTensor/scs:status"/>
-    <xsl:template match="scs:momentTensor/scs:cmtName"/>
-    <xsl:template match="scs:momentTensor/scs:cmtVersion"/>
-    <xsl:template match="scs:momentTensor/scs:phaseSetting"/>
-    <xsl:template match="scs:stationMagnitude/scs:passedQC"/>
-    <xsl:template match="scs:pdf"/>
 
     <!-- Converts a scs magnitude/stationMagnitude to a qml
          magnitude/stationMagnitude -->
@@ -323,7 +317,11 @@
                     </xsl:call-template>
                 </originID>
             </xsl:if>
-            <xsl:apply-templates/>
+
+            <!-- Put the QuakeML nodes at the beginning -->
+            <xsl:apply-templates select="*[not(self::scs:passedQC)]" />
+            <!-- Put the non-QuakeML nodes at the end -->
+            <xsl:apply-templates select="scs:passedQC" mode="scs-only" />
         </xsl:element>
     </xsl:template>
 
@@ -534,7 +532,11 @@
                     </xsl:call-template>
                 </xsl:attribute>
             </xsl:if>
-            <xsl:apply-templates/>
+
+            <!-- Put the QuakeML nodes at the beginning -->
+            <xsl:apply-templates select="*[not(self::scs:start|self::scs:end)]" />
+            <!-- Put the non-QuakeML nodes at the end -->
+            <xsl:apply-templates select="scs:start|scs:end" mode="scs-only" />
         </xsl:element>
     </xsl:template>
 
@@ -555,6 +557,60 @@
             </xsl:choose>
         </xsl:attribute>
     </xsl:template>
+
+<!--
+    ************************************************************************
+    Unmapped nodes
+    ************************************************************************
+-->
+
+    <xsl:template match="scs:creationInfo">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- Put the QuakeML nodes at the beginning -->
+            <xsl:apply-templates select="*[not(self::scs:modificationTime)]" />
+            <!-- Put the non-QuakeML nodes at the end -->
+            <xsl:apply-templates select="scs:modificationTime" mode="scs-only" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="scs:momentTensor">
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*"/>
+
+            <!-- Put the QuakeML nodes at the beginning -->
+            <xsl:apply-templates select="*[not(self::scs:stationMomentTensorContribution
+                                               | self::scs:status
+                                               | self::scs:cmtName
+                                               | self::scs:cmtVersion
+                                               | self::scs:phaseSetting)]" />
+            <!-- Put the non-QuakeML nodes at the end -->
+            <xsl:apply-templates select="scs:stationMomentTensorContribution
+                                         | scs:status
+                                         | scs:cmtName
+                                         | scs:cmtVersion
+                                         | scs:phaseSetting" mode="scs-only" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="scs:pdf">
+        <xsl:apply-templates select="." mode="scs-only" />
+    </xsl:template>
+
+    <xsl:template match="node()|@*" mode="scs-only">
+      <xsl:copy>
+        <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:template>
+
+    <!-- Keep seiscomp namespace for unmapped node -->
+    <xsl:template match="scs:*" mode="scs-only">
+      <xsl:element name="scs:{local-name()}">
+        <xsl:apply-templates select="@*|node()" mode="scs-only" />
+      </xsl:element>
+  </xsl:template>
+
 
 <!--
     ************************************************************************


### PR DESCRIPTION
In the QuakeML format, there is the possibility to create custom nodes. This PR modify the XSLT stylesheets to put the seiscomp nodes that are not mapped in QuakeML in these custom fields. This allows some round-trip conversion without loss of data. For instance, the `pdf` node doesn't exist in QuakeML:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.11" version="0.11">
  <EventParameters publicID="smi:test/EventParameters">
    <origin publicID="smi:test/origin">
      <time>
        <value>2018-12-12T00:00:00.000000Z</value>
        <pdf>
          <variable>2018-12-12T00:00:00 2018-12-12T00:00:00 2018-12-12T00:00:00</variable>
          <probability>0.4 1.1 1.3</probability>
        </pdf>
      </time>
      <latitude>
        <value>20</value>
      </latitude>
      <longitude>
        <value>100</value>
      </longitude>
    </origin>
    <event publicID="smi:test/event">
      <originReference>smi:test/origin</originReference>
    </event>
  </EventParameters>
</seiscomp>
```

The XSLT conversion puts this `pdf` node in a custom tags.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns="http://quakeml.org/xmlns/bed/1.2">
  <eventParameters publicID="smi:test/EventParameters">
    <event publicID="smi:test/event">
      <origin publicID="smi:test/origin">
        <time>
          <value>2018-12-12T00:00:00.000000Z</value>
          <scs:pdf xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.11">
            <scs:variable>2018-12-12T00:00:00 2018-12-12T00:00:00 2018-12-12T00:00:00</scs:variable>
            <scs:probability>0.4 1.1 1.3</scs:probability>
          </scs:pdf>
        </time>
        <latitude>
          <value>20</value>
        </latitude>
        <longitude>
          <value>100</value>
        </longitude>
      </origin>
    </event>
  </eventParameters>
</q:quakeml>
```

This QuakeML file contains the `pdf` node in a custom namespace and is still valid. Moreover, the reverse conversion (using [this stylesheet](https://github.com/obspy/obspy/blob/master/obspy/io/seiscomp/data/quakeml_1.2__sc3ml_0.10.xsl)) generates exactly the same sc3ml file.

The custom namespace can also be defined in the header:

```diff
@@ -183,7 +183,7 @@
         xmlns:qml="http://quakeml.org/xmlns/quakeml/1.0"
         xmlns="http://quakeml.org/xmlns/bed/1.2"
         xmlns:q="http://quakeml.org/xmlns/quakeml/1.2"
-        exclude-result-prefixes="scs qml xsl">
+        exclude-result-prefixes="qml xsl">
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
     <xsl:strip-space elements="*"/>
```

The generated file looks like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<q:quakeml xmlns:q="http://quakeml.org/xmlns/quakeml/1.2" xmlns:scs="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.11" xmlns="http://quakeml.org/xmlns/bed/1.2">
  <eventParameters publicID="smi:test/EventParameters">
    <event publicID="smi:test/event">
      <origin publicID="smi:test/origin">
        <time>
          <value>2018-12-12T00:00:00.000000Z</value>
          <scs:pdf>
            <scs:variable>2018-12-12T00:00:00 2018-12-12T00:00:00 2018-12-12T00:00:00</scs:variable>
            <scs:probability>0.4 1.1 1.3</scs:probability>
          </scs:pdf>
        </time>
        <latitude>
          <value>20</value>
        </latitude>
        <longitude>
          <value>100</value>
        </longitude>
      </origin>
    </event>
  </eventParameters>
</q:quakeml>
```

But it will always be there even if there are no custom tags in the file. I don't know if it's better or not.

Let me know what you think about this!