### PR TITLE
BUG: Seiscomp::Core::stringify truncates the resulting string

### DIFF
--- a/src/trunk/libs/seiscomp3/core/strings.cpp
+++ b/src/trunk/libs/seiscomp3/core/strings.cpp
@@ -319,7 +319,7 @@ std::string stringify(const char* fmt, ...) {
 	va_start(params, fmt);
 	nsize = vsnprintf(buffer, size, fmt, params);
 
-	while ( nsize > size ) { //fail -> create dynamic buffer with more space
+	while ( nsize >= size ) { //fail -> create dynamic buffer with more space
 		if ( dynamicBuffer != NULL )
 			delete [] dynamicBuffer;
 


### PR DESCRIPTION
vsnprintf returns the number of characters printed EXCLUDING the null byte