### PR TITLE
[trunk] fix dataselect restricted handling

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/dataselect.py
+++ b/src/trunk/apps/fdsnws/fdsnws/dataselect.py
@@ -537,7 +537,13 @@ class FDSNDataSelect(resource.Resource):
 		# iterate over inventory networks
 		for s in ro.streams:
 			for net in self._networkIter(s):
+				netRestricted = utils.isRestricted(net)
+				if not tracker and netRestricted and not self.__user:
+					continue
 				for sta in self._stationIter(net, s):
+					staRestricted = utils.isRestricted(sta)
+					if not tracker and staRestricted and not self.__user:
+						continue
 					for loc in self._locationIter(sta, s):
 						for cha in self._streamIter(loc, s):
 							try:
@@ -552,7 +558,8 @@ class FDSNDataSelect(resource.Resource):
 							except Exception:
 								end_time = s.time.end
 
-							if utils.isRestricted(cha) and \
+							if ( netRestricted or staRestricted or \
+							     utils.isRestricted(cha) ) and \
 							    (not self.__user or (self.__access and
 							     not self.__access.authorize(self.__user,
 							         net.code(), sta.code(), loc.code(),


### PR DESCRIPTION
The SC3 datamodel includes a restricted attribute at network, station and channel level.

A FDSNWS station query with ```restricted=false``` will exclude all streams with a restricted flag set to ```true``` either on the network, station or channel level.

In contrast, the FDSWS dataselect service currently evaluates the restricted flag only on the channel level. Restricted channels are only available after authentication using the queryauth URL. However, streams with restricted network but non restricted channel are public available.

This pull request changes the dataselect service to require authentication if a stream is restricted either on the network, station or channel level. Also the iteration is stopped early at network or station level if the restricted flag is found but no authentication was performed.