### PR TITLE
Set file 'not found' log message to WARNING level

### DIFF
--- a/src/trunk/libs/seiscomp3/io/recordstream/sdsarchive.cpp
+++ b/src/trunk/libs/seiscomp3/io/recordstream/sdsarchive.cpp
@@ -506,7 +506,7 @@ bool SDSArchive::stepStream() {
 			_recstream.clear();
 			_recstream.open(_currentFilename.c_str(), ios_base::in | ios_base::binary);
 			if ( !_recstream.is_open() ) {
-				SEISCOMP_DEBUG("+ %s (not found)", _currentFilename.c_str());
+				SEISCOMP_WARNING("+ %s (not found)", _currentFilename.c_str());
 			}
 			else {
 				SEISCOMP_DEBUG("+ %s (init:%d)", _currentFilename.c_str(), first?1:0);


### PR DESCRIPTION
Hi,

This pull request changes the logging level for reporting when the recordstream cannot find a file to WARNING.  This will cause the message to be shown during 'normal' operation and will allow badly configured metadata or file paths to be more easily identified by server administrators.

Thanks for creating SeisComp!