### PR TITLE
fix evaluation status

### DIFF
--- a/src/trunk/libs/seiscomp3/datamodel/utils.h
+++ b/src/trunk/libs/seiscomp3/datamodel/utils.h
@@ -65,7 +65,7 @@ char objectStatusToChar(const T *o) {
 	catch ( ... ) {}
 
 	try {
-		if ( o->evaluationMode() == 'M' )
+		if ( o->evaluationMode() == DataModel::MANUAL )
 			return 'M';
 	}
 	catch ( ... ) {}

--- a/src/trunk/libs/seiscomp3/datamodel/utils.h
+++ b/src/trunk/libs/seiscomp3/datamodel/utils.h
@@ -65,7 +65,7 @@ char objectStatusToChar(const T *o) {
 	catch ( ... ) {}
 
 	try {
-		if ( o->evaluationMode() == DataModel::MANUAL )
+		if ( o->evaluationMode() == 'MANUAL' )
 			return 'M';
 	}
 	catch ( ... ) {}


### PR DESCRIPTION
Before the correction, the column Stat in the event tab was set to A in the case the evaluation status was not defined and that evaluation mode was equal to "manual".
I corrected the bug to replace A by M.