### PR TITLE
[fdsnws] Fix error message in event.py

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/event.py
+++ b/src/trunk/apps/fdsnws/fdsnws/event.py
@@ -308,7 +308,7 @@ class FDSNEvent(BaseResource):
         # Create database query
         db = DatabaseInterface.Open(Application.Instance().databaseURI())
         if db is None:
-            msg = "could not connect to database: %s" % dbq.errorMsg()
+            msg = "could not connect to database"
             return self.renderErrorPage(req, http.SERVICE_UNAVAILABLE, msg, ro)
 
         dbq = DataModel.DatabaseQuery(db)


### PR DESCRIPTION
There is a small error in this error message at `event.py`:

```
        # Create database query
        db = DatabaseInterface.Open(Application.Instance().databaseURI())
        if db is None:
            msg = "could not connect to database: %s" % dbq.errorMsg()
            return self.renderErrorPage(req, http.SERVICE_UNAVAILABLE, msg, ro)

        dbq = DataModel.DatabaseQuery(db)
```

which causes an `UnboundLocalError: local variable 'dbq' referenced before assignment` exception.