### PR TITLE
Fixes static magnitude reprocessing in combination with median

### DIFF
--- a/src/trunk/apps/processing/scmag/magtool.cpp
+++ b/src/trunk/apps/processing/scmag/magtool.cpp
@@ -1626,7 +1626,18 @@ bool MagTool::processOriginUpdateOnly(DataModel::Origin* origin) {
 			if ( _keepWeights ) {
 				// Use preset weights
 				if ( averageMethod.type == Median || averageMethod.type == TrimmedMedian ) {
-					val = Math::Statistics::median(mv);
+					vector<double> significantValues;
+					for ( size_t i = 0; i < mv.size(); ++i ) {
+						if ( weights[i] > 0.0 )
+							significantValues.push_back(mv[i]);
+					}
+
+					// A median for zero values is not defined
+					if ( significantValues.empty() )
+						return false;
+
+					val = Math::Statistics::median(significantValues);
+
 					stdev = 0;
 					double cumw = 0.0;
 					for ( size_t i = 0; i < mv.size(); ++i ) {


### PR DESCRIPTION
If the median has been used to compute a network magnitude then reprocessing with `--keep-weights` produced the wrong result. This PR resolves the issue. It has been reported and tested by SED.