### PR TITLE
Build/jakarta/2018.327

### DIFF
--- a/src/gui-qt4/apps/descriptions/global_gui.xml
+++ b/src/gui-qt4/apps/descriptions/global_gui.xml
@@ -1144,6 +1144,28 @@
 							</description>
 						</parameter>
 					</group>
+					<group name="magnitudes">
+						<parameter name="enabled" type="boolean" default="false">
+							<description>
+							Enable/Disable magnitude range filtering.
+							</description>
+						</parameter>
+						<parameter name="method" type="int" default="1">
+							<description>
+							Method of magnitude selection, defined by an integer [ 0 for &quot;min./max.&quot; ; 1 = &quot;min.&quot; ; 2 = &quot;max.&quot; ]
+							</description>
+						</parameter>
+						<parameter name="minimum" type="double" default="5.0">
+							<description>
+							Minimum magnitude used to filter event list request.
+							</description>
+						</parameter>
+						<parameter name="maximum" type="double" default="12.0">
+							<description>
+							Maximum magnitude used to filter event list request.
+							</description>
+						</parameter>
+					</group>
 				</group>
 				<group name="scripts">
 					<parameter name="columns" type="list:string">

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.cpp
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.cpp
@@ -2875,6 +2875,7 @@ void EventListView::readFromDatabase(const Filter &filter) {
 	if ( _withOrigins ) numberOfSteps -= eventDiff*20;
 	if ( _withFocalMechanisms ) numberOfSteps -= eventDiff*20;
 
+	if (numberOfSteps == 0 ) numberOfSteps+=1;
 	progress.setRange(0, numberOfSteps);
 
 	// Read comments

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.h
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.h
@@ -178,9 +178,11 @@ class SC_GUI_API EventListView : public QWidget {
 		void itemPressed(QTreeWidgetItem*,int);
 		void copyRowToClipboard();
 
+		void readMagnitudeRange();
 		void readLastDays();
 		void readInterval();
 
+		void onUseMagRange(int checked);
 		void onShowOtherEvents(int checked);
 		void onShowForeignEvents(int checked);
 		void onHideOutsideRegion(int checked);
@@ -192,6 +194,7 @@ class SC_GUI_API EventListView : public QWidget {
 		void headerContextMenuRequested(const QPoint &);
 		void waitDialogDestroyed(QObject *o);
 
+		void magnitudeSelectionChanged(int index);
 		void regionSelectionChanged(int index);
 		void changeRegion();
 
@@ -303,6 +306,8 @@ class SC_GUI_API EventListView : public QWidget {
 		bool                                _checkEventAgency;
 		bool                                _showOnlyLatestPerAgency;
 		int                                 _regionIndex;
+		bool                                _selectMagnitudeRange;
+		int                                 _magnitudeMethod;
 };
 
 

--- a/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.ui
+++ b/src/gui-qt4/libs/seiscomp3/gui/datamodel/eventlistview.ui
@@ -102,6 +102,124 @@
           </property>
          </widget>
         </item>
+	<item>
+         <spacer>
+          <property name="orientation" >
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" >
+           <size>
+            <width>32</width>
+            <height>29</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+	<item>
+	 <widget class="QCheckBox" name="cbFilterMagnitudes" >
+	  <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>8</hsizetype>
+            <vsizetype>5</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip" >
+           <string>Enable/Disable events selection using the magnitude range min: "min." max: "max:"</string>
+          </property>
+          <property name="text" >
+           <string>Select magnitude</string>
+          </property>
+          <property name="checked" >
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+	<item>
+         <widget class="QComboBox" name="lstMagnitudeMethod" >
+	  <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>4</hsizetype>
+            <vsizetype>5</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip" >
+           <string>Choose the method for magnitude selection.</string>
+          </property>
+          <property name="sizeAdjustPolicy" >
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+	 </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="minmagLabel" >
+          <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>4</hsizetype>
+            <vsizetype>5</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text" >
+           <string>min.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="minmagBox" >
+          <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>5</hsizetype>
+            <vsizetype>0</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimum" >
+           <number>0.0</number>
+          </property>
+	  <property name="decimals" >
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
+	<item>
+         <widget class="QLabel" name="maxmagLabel" >
+          <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>4</hsizetype>
+            <vsizetype>5</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text" >
+           <string>max.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="maxmagBox" >
+          <property name="sizePolicy" >
+           <sizepolicy>
+            <hsizetype>5</hsizetype>
+            <vsizetype>0</vsizetype>
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+	  <property name="minimum" >
+           <number>0.0</number>
+          </property>
+	  <property name="decimals" >
+           <number>1</number>
+          </property>
+         </widget>
+        </item>
         <item>
          <spacer>
           <property name="orientation" >


### PR DESCRIPTION
One commit is a bug fix to remove GTK3 warnings using CentOS7, that appear when a database request return no events.
Example of GTK messages :

`(scolv:25241): Gtk-CRITICAL **: 00:35:00.695: IA__gtk_progress_configure: assertion 'value >= min && value <= max' failed`

Second commit add an optional magnitude range selection for the Gui applications and their events list viewer, using a minimum magnitude or a maximum magnitude or a specific range.

To activate this feature user must add for example in scolv.cfg :
`  # Enable/Disable magnitude range filtering.`
`     eventlist.filter.magnitudes.enabled = true`
   

Magnitude selection is used to enhanced the database request. For the origin locator viewer applications (scolv). It is usefull to be able to select a specific magnitude range when request is done over many years to avoid to import all origins. 


