### PR TITLE
Manage backward compatibility with Python2.7

### DIFF
--- a/src/nettab/libs/python/nettab/basesc3.py
+++ b/src/nettab/libs/python/nettab/basesc3.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from seiscomp3 import DataModel, Core, Config
 from .helpers import parsers
 import datetime

--- a/src/nettab/libs/python/nettab/convertUtils.py
+++ b/src/nettab/libs/python/nettab/convertUtils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import csv
 import re

--- a/src/nettab/libs/python/nettab/lineType.py
+++ b/src/nettab/libs/python/nettab/lineType.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from datetime import datetime
 import decimal
 import shlex

--- a/src/nettab/libs/python/nettab/nodesi.py
+++ b/src/nettab/libs/python/nettab/nodesi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from .lineType import Dl, Se, Ff, Pz, Cl
 from .basesc3 import sc3
 import sys

--- a/src/nettab/libs/python/nettab/nodesnslc.py
+++ b/src/nettab/libs/python/nettab/nodesnslc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from .lineType import Sl, Nw, Sr, Sg
 from .nodesi import Instruments
 from .basesc3 import sc3

--- a/src/nettab/libs/python/nettab/tab.py
+++ b/src/nettab/libs/python/nettab/tab.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from .lineType import Nw, Sg, Sr, Sl, Sa, Na, Dl, Se, Ff, Pz, Ia, Cl
 from .nodesi import Instruments
 from .nodesnslc import Network, StationGroup, DontFit


### PR DESCRIPTION
We are getting following error when we try to run seiscomp3 with python-2.7.5

```
Python 2.7.5 (default, Aug  7 2019, 00:51:29) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux2
```

```
    print("Network: %s" % line, file=sys.stderr)
                                    ^
SyntaxError: invalid syntax

```
