### PR TITLE
[fdsnws] Strictly parse HTTP GET requests

### DIFF
--- a/src/trunk/apps/fdsnws/fdsnws/availability.py
+++ b/src/trunk/apps/fdsnws/fdsnws/availability.py
@@ -73,11 +73,11 @@ class _AvailabilityRequestOptions(RequestOptions):
 
     POSTParams = RequestOptions.POSTParams + PQuality + PMerge + POrderBy + \
                  PLimit + PIncludeRestricted
-
+    GETParams = RequestOptions.GETParams + POSTParams
 
     #--------------------------------------------------------------------------
-    def __init__(self, args=None):
-        RequestOptions.__init__(self, args)
+    def __init__(self):
+        RequestOptions.__init__(self)
 
         self.service = 'availability-base'
         self.quality = None
@@ -184,8 +184,8 @@ class _AvailabilityRequestOptions(RequestOptions):
 class _AvailabilityExtentRequestOptions(_AvailabilityRequestOptions):
 
     #--------------------------------------------------------------------------
-    def __init__(self, args=None):
-        _AvailabilityRequestOptions.__init__(self, args)
+    def __init__(self):
+        _AvailabilityRequestOptions.__init__(self)
         self.service = 'availability-extent'
 
         self.showLatestUpdate = True
@@ -224,10 +224,12 @@ class _AvailabilityQueryRequestOptions(_AvailabilityRequestOptions):
 
     POSTParams = _AvailabilityRequestOptions.POSTParams + PMergeGaps + \
                  PShow + PExcludeTooLarge
+    GETParams = _AvailabilityRequestOptions.GETParams + PMergeGaps + \
+                PShow + PExcludeTooLarge
 
     #--------------------------------------------------------------------------
-    def __init__(self, args=None):
-        _AvailabilityRequestOptions.__init__(self, args)
+    def __init__(self):
+        _AvailabilityRequestOptions.__init__(self)
         self.service = 'availability-query'
 
         self.orderBy = None
@@ -284,8 +286,9 @@ class _Availability(BaseResource):
     #--------------------------------------------------------------------------
     def render_GET(self, req):
         # Parse and validate GET parameters
-        ro = self._createRequestOptions(req.args)
+        ro = self._createRequestOptions()
         try:
+            ro.parseGET(req.args)
             ro.parse()
 
             # the GET operation supports exactly one stream filter
@@ -594,8 +597,8 @@ class FDSNAvailabilityExtent(_Availability):
 
 
     #--------------------------------------------------------------------------
-    def _createRequestOptions(self, args=None):
-        return _AvailabilityExtentRequestOptions(args)
+    def _createRequestOptions(self):
+        return _AvailabilityExtentRequestOptions()
 
 
     #--------------------------------------------------------------------------
@@ -864,8 +867,8 @@ class FDSNAvailabilityQuery(_Availability):
 
 
     #--------------------------------------------------------------------------
-    def _createRequestOptions(self, args=None):
-        return _AvailabilityQueryRequestOptions(args)
+    def _createRequestOptions(self):
+        return _AvailabilityQueryRequestOptions()
 
 
     #--------------------------------------------------------------------------

--- a/src/trunk/apps/fdsnws/fdsnws/dataselect.py
+++ b/src/trunk/apps/fdsnws/fdsnws/dataselect.py
@@ -63,10 +63,11 @@ class _DataSelectRequestOptions(RequestOptions):
 
     POSTParams = RequestOptions.POSTParams + \
         PQuality + PMinimumLength + PLongestOnly
+    GETParams = RequestOptions.GETParams + POSTParams
 
     #---------------------------------------------------------------------------
-    def __init__(self, args=None):
-        RequestOptions.__init__(self, args)
+    def __init__(self):
+        RequestOptions.__init__(self)
         self.service = 'fdsnws-dataselect'
 
         self.quality = self.QualityValues[0]
@@ -396,10 +397,11 @@ class FDSNDataSelect(BaseResource):
 
     #---------------------------------------------------------------------------
     def render_GET(self, req):
-        # Parse and validate POST parameters
-        ro = _DataSelectRequestOptions(req.args)
+        # Parse and validate GET parameters
+        ro = _DataSelectRequestOptions()
         ro.userName = self.__user and self.__user.get('mail')
         try:
+            ro.parseGET(req.args)
             ro.parse()
             # the GET operation supports exactly one stream filter
             ro.streams.append(ro)

--- a/src/trunk/apps/fdsnws/fdsnws/event.py
+++ b/src/trunk/apps/fdsnws/fdsnws/event.py
@@ -102,6 +102,13 @@ class _EventRequestOptions(RequestOptions):
         ]
     }
 
+    GETParams = RequestOptions.GETParams + RequestOptions.GeoParams + \
+        RequestOptions.OutputParams + PMinDepth + PMaxDepth + PMinMag + \
+        PMaxMag + PMagType + PEventType + PAllOrigins + PAllMags + \
+        PArrivals + PEventID + PLimit + POffset + POrderBy + PContributor + \
+        PCatalog + PUpdateAfter + PPicks + PFM + PAllFMs + PStaMTs + \
+        PComments + PFormatted
+
     #---------------------------------------------------------------------------
     class Depth:
         def __init__(self):
@@ -116,8 +123,8 @@ class _EventRequestOptions(RequestOptions):
             self.type = None
 
     #---------------------------------------------------------------------------
-    def __init__(self, args):
-        RequestOptions.__init__(self, args)
+    def __init__(self):
+        RequestOptions.__init__(self)
         self.service = 'fdsnws-event'
 
         self.depth = None
@@ -274,8 +281,9 @@ class FDSNEvent(BaseResource):
     #---------------------------------------------------------------------------
     def render_GET(self, req):
         # Parse and validate GET parameters
-        ro = _EventRequestOptions(req.args)
+        ro = _EventRequestOptions()
         try:
+            ro.parseGET(req.args)
             ro.parse()
         except ValueError as e:
             Logging.warning(str(e))

--- a/src/trunk/apps/fdsnws/fdsnws/request.py
+++ b/src/trunk/apps/fdsnws/fdsnws/request.py
@@ -78,6 +78,7 @@ class RequestOptions:
     OutputParams = PFormat + PNoData
 
     POSTParams = OutputParams
+    GETParams = StreamParams + SimpleTimeParams
 
     #---------------------------------------------------------------------------
     class Channel:
@@ -239,7 +240,7 @@ class RequestOptions:
             return False
 
     #---------------------------------------------------------------------------
-    def __init__(self, args=None):
+    def __init__(self):
         self.service = ""
         self.accessTime = Time.GMT()
         self.userName = None
@@ -251,12 +252,7 @@ class RequestOptions:
         self.noData = http.NO_CONTENT
         self.format = None
 
-        # transform keys to lower case
         self._args = {}
-        if args is not None:
-            for k, v in args.items():
-                self._args[py3ustr(k.lower())] = py3ustrlist(v)
-
         self.streams = []  # 1 entry for GET, multipl
 
     #---------------------------------------------------------------------------
@@ -504,6 +500,17 @@ class RequestOptions:
                 values.append(v)
 
         return values
+
+    #---------------------------------------------------------------------------
+    def parseGET(self, args):
+        # transform keys to lower case
+        if args is not None:
+            for k, v in args.items():
+                k = py3ustr(k.lower())
+                if k not in self.GETParams:
+                    raise ValueError("invalid param: %s" % k)
+
+                self._args[k] = py3ustrlist(v)
 
     #---------------------------------------------------------------------------
     def parsePOST(self, content):

--- a/src/trunk/apps/fdsnws/fdsnws/station.py
+++ b/src/trunk/apps/fdsnws/fdsnws/station.py
@@ -66,10 +66,12 @@ class _StationRequestOptions(RequestOptions):
     POSTParams = RequestOptions.POSTParams + RequestOptions.GeoParams + \
         PLevel + PIncludeRestricted + PIncludeAvailability + \
         PUpdateAfter + PMatchTimeSeries + PFormatted
+    GETParams = RequestOptions.GETParams + RequestOptions.WindowTimeParams + \
+        POSTParams
 
     #---------------------------------------------------------------------------
-    def __init__(self, args=None):
-        RequestOptions.__init__(self, args)
+    def __init__(self):
+        RequestOptions.__init__(self)
         self.service = 'fdsnws-station'
 
         self.includeSta = True
@@ -263,8 +265,9 @@ class FDSNStation(BaseResource):
     #---------------------------------------------------------------------------
     def render_GET(self, req):
         # Parse and validate GET parameters
-        ro = _StationRequestOptions(req.args)
+        ro = _StationRequestOptions()
         try:
+            ro.parseGET(req.args)
             ro.parse()
             # the GET operation supports exactly one stream filter
             ro.streams.append(ro)


### PR DESCRIPTION
Hi,

this PR fixes the issue that unknown query filter parameters of HTTP GET requests were silently omitted. Instead, HTTP status code 400 should be returned (in accordance with the [FDSN webservice specs](https://www.fdsn.org/webservices/)).

```bash
$  curl -v -o - "http://localhost:8080/fdsnws/station/1/query?net=NET&foo=bar&foobar=foobar"
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /fdsnws/station/1/query?net=NET&foo=bar&foobar=foobar HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8080
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Content-Length: 240
< Access-Control-Expose-Headers: WWW-Authenticate
< Server: SeisComP3-FDSNWS/1.2.4
< Date: Sun, 07 Jun 2020 16:15:52 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: Authorization
< Content-Type: text/plain
< 
Error 400: Bad Request

invalid params: foobar, foo

Usage details are available from /fdsnws/station/1/

Request:
/fdsnws/station/1/query?net=NET&foo=bar&foobar=foobar

Request Submitted:
2020-06-07T16:15:52.641935

Service Version:
1.1.2
* Connection #0 to host localhost left intact

```

Some remaining open questions from my side:
- How should the SC3 `fdsnws-event` implementation treat query filter parameters not officially supported by the FDSNWS specs? I'm referring to https://github.com/SeisComP3/seiscomp3/blob/0e70d3fc8001f0cb8d43cafdb56ea9abc64dbf60/src/trunk/apps/fdsnws/fdsnws/event.py#L82-L88
- Since I'm not (yet) familiar with the branching model in use, I based this PR on `build/jakarta/2018.327`. Do you want me to base it rather on `master` (this would imply some changes due to Python3)?

Note that for HTTP POST requests services behaved as expected:
```bash
$ cat data
foo=bar

NET STA LOC CHA 2020-01-01 2020-01-02
$ curl -X POST -v -o - -H "Content-Type: text/plain" --data-binary @data "http://localhost:8080/fdsnws/station/1/query"
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /fdsnws/station/1/query HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8080
> Accept: */*
> Content-Type: plain/text
> Content-Length: 47
> 
* upload completely sent off: 47 out of 47 bytes
< HTTP/1.1 400 Bad Request
< Content-Length: 210
< Access-Control-Expose-Headers: WWW-Authenticate
< Server: SeisComP3-FDSNWS/1.2.4
< Date: Sun, 07 Jun 2020 16:12:36 GMT
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: Authorization
< Content-Type: text/plain
< 
Error 400: Bad Request

invalid parameter in line 1

Usage details are available from /fdsnws/station/1/

Request:
/fdsnws/station/1/query

Request Submitted:
2020-06-07T16:12:36.656888

Service Version:
1.1.2
* Connection #0 to host localhost left intact
```